### PR TITLE
[codex] Add Gemini AI picks column

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,7 @@ make seed-staging    # SSH: copy prod DB → staging DB on VPS
 
 **Data pipeline (build-time, legacy):**
 1. `scripts/parse_goodreads.py` — parses Goodreads CSV export → `data/books.json`
-2. `scripts/generate_llm.py` — calls Anthropic + OpenAI APIs → `data/llm_cache.json` (skips if SHA-256 hash of read shelf is unchanged)
+2. `scripts/generate_llm.py` — calls Anthropic + OpenAI + Gemini APIs → `data/llm_cache.json` (skips if SHA-256 hash of read shelf is unchanged)
 
 **Runtime:**
 - `api/main.py` — FastAPI server; reads from SQLite via `BookshelfDB` (or JSON via `BookshelfStore` as fallback)
@@ -89,8 +89,10 @@ Loaded automatically from `.env` at repo root via `load_env_file()`. See `.env.e
 |----------|---------|-------|
 | `ANTHROPIC_API_KEY` | — | Required for taste profile + recommendations |
 | `OPENAI_API_KEY` | — | Required for GPT recommendations |
+| `GEMINI_API_KEY` | — | Required for Gemini recommendations |
 | `ANTHROPIC_MODEL` | `claude-opus-4-20250514` | |
 | `OPENAI_MODEL` | `gpt-4.1` | |
+| `GEMINI_MODEL` | `gemini-3-flash-preview` | |
 | `DB_PATH` | — | Path to SQLite DB; enables SQLite backend when set and file exists |
 | `BOOKS_DATA` | `data/books.json` | JSON fallback when `DB_PATH` is unset |
 | `LLM_CACHE_DATA` | `data/llm_cache.json` | JSON fallback when `DB_PATH` is unset |
@@ -103,7 +105,7 @@ Loaded automatically from `.env` at repo root via `load_env_file()`. See `.env.e
 ```
 GET    /api/books              # All shelves + stats
 GET    /api/taste-profile      # Anthropic-generated reading taste analysis
-GET    /api/recommendations    # Anthropic + OpenAI book recommendations (side-by-side)
+GET    /api/recommendations    # Anthropic + OpenAI + Gemini book recommendations
 GET    /api/health             # Server status + data availability flags + data_backend (sqlite/json)
 GET    /api/lookup?q=...       # Google Books metadata search
 GET    /api/llm-status         # LLM regeneration status (idle/running)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Personal reading site for [book.tanxy.net](https://book.tanxy.net), built from a
 
 - Stores book data in a self-owned SQLite database (migrated from Goodreads CSV)
 - Generates a build-time taste profile from the read shelf
-- Generates side-by-side AI Picks (recommendations) from Anthropic and OpenAI, using reviews as primary signal; can surface books already on the to-read shelf
+- Generates three-way AI Picks (recommendations) from Anthropic, OpenAI, and Gemini, using reviews as primary signal; can surface books already on the to-read shelf
 - Serves everything through a small FastAPI backend
 - Renders a single-file frontend with search, filters, sort controls, and expandable book cards
 - Supports adding and editing books directly through the site (auth required)
@@ -53,6 +53,7 @@ Required:
 
 - `ANTHROPIC_API_KEY`
 - `OPENAI_API_KEY`
+- `GEMINI_API_KEY`
 
 Optional:
 
@@ -60,6 +61,7 @@ Optional:
 - `BOOKSHELF_AUTH_TOKEN` — bearer token for write endpoints
 - `ANTHROPIC_MODEL`
 - `OPENAI_MODEL`
+- `GEMINI_MODEL`
 - `LLM_DRY_RUN`
 - `ENVIRONMENT`
 - `BOOKS_DATA` — JSON fallback when `DB_PATH` is unset
@@ -154,7 +156,7 @@ make seed-staging          # copy prod DB → staging DB on VPS
 ```
 GET    /api/books              # All shelves + stats
 GET    /api/taste-profile      # Anthropic-generated reading taste analysis
-GET    /api/recommendations    # Side-by-side Anthropic + OpenAI recommendations
+GET    /api/recommendations    # Three-way Anthropic + OpenAI + Gemini recommendations
 GET    /api/health             # Server status + data backend (sqlite/json)
 GET    /api/lookup?q=...       # Google Books metadata search
 GET    /api/llm-status         # LLM regeneration status (idle/running)
@@ -184,7 +186,7 @@ The app auto-detects: if `DB_PATH` is set and the file exists, it uses SQLite. O
 
 `scripts/generate_llm.py` computes a SHA-256 hash from the sorted read shelf using title, author, rating, and review. If the hash matches the cache, generation is skipped unless `--force` is used.
 
-Anthropic powers the taste profile and one side of the recommendations. OpenAI powers the second side. If one provider fails, the other still gets cached and displayed.
+Anthropic powers the taste profile and one recommendation column. OpenAI and Gemini power the other two recommendation columns. If one provider fails, the others still get cached and displayed.
 
 If `LLM_DRY_RUN=true`, the generator writes placeholder content marked with `[DRY RUN]` without making live API calls.
 

--- a/bookshelf_data.py
+++ b/bookshelf_data.py
@@ -76,6 +76,7 @@ def default_llm_cache() -> dict[str, Any]:
         "recommendations": {
             "opus": {"model": None},
             "gpt45": {"model": None},
+            "gemini": {"model": None},
         },
     }
 
@@ -328,6 +329,7 @@ class BookshelfDB:
         recommendations = self._get_llm_cache_value("recommendations") or {
             "opus": {"model": None},
             "gpt45": {"model": None},
+            "gemini": {"model": None},
         }
 
         return {

--- a/deploy/staging.env.example
+++ b/deploy/staging.env.example
@@ -1,6 +1,7 @@
 # Staging environment
 ANTHROPIC_API_KEY=your-anthropic-api-key
 OPENAI_API_KEY=your-openai-api-key
+GEMINI_API_KEY=your-gemini-api-key
 
 # Staging app settings
 ENVIRONMENT=staging
@@ -12,3 +13,4 @@ BOOKSHELF_CORS_ORIGINS=https://dev.book.tanxy.net
 # Cheap staging model overrides for when LLM_DRY_RUN=false
 ANTHROPIC_MODEL=claude-3-haiku-20240307
 OPENAI_MODEL=gpt-4.1-nano
+GEMINI_MODEL=gemini-3-flash-preview

--- a/scripts/generate_llm.py
+++ b/scripts/generate_llm.py
@@ -41,9 +41,11 @@ from bookshelf_data import (
 
 ANTHROPIC_API_URL = "https://api.anthropic.com/v1/messages"
 OPENAI_API_URL = "https://api.openai.com/v1/chat/completions"
+GEMINI_API_BASE_URL = "https://generativelanguage.googleapis.com/v1beta/models"
 
 ANTHROPIC_MODEL = os.getenv("ANTHROPIC_MODEL", "claude-opus-4-20250514")
 OPENAI_MODEL = os.getenv("OPENAI_MODEL", "gpt-4.1")
+GEMINI_MODEL = os.getenv("GEMINI_MODEL", "gemini-3-flash-preview")
 REQUEST_TIMEOUT_SECONDS = 120
 ROOT_DIR = Path(__file__).resolve().parents[1]
 PROMPTS_DIR = ROOT_DIR / "scripts" / "prompts"
@@ -54,6 +56,7 @@ load_env_file(ROOT_DIR / ".env")
 
 ANTHROPIC_MODEL = os.getenv("ANTHROPIC_MODEL", ANTHROPIC_MODEL)
 OPENAI_MODEL = os.getenv("OPENAI_MODEL", OPENAI_MODEL)
+GEMINI_MODEL = os.getenv("GEMINI_MODEL", GEMINI_MODEL)
 LLM_DRY_RUN = env_truthy("LLM_DRY_RUN", default=False)
 
 
@@ -306,6 +309,45 @@ async def call_openai_json(
     return extract_json_object(text)
 
 
+async def call_gemini_json(
+    client: httpx.AsyncClient, api_key: str, prompt: str, max_tokens: int
+) -> dict[str, Any]:
+    response = await client.post(
+        f"{GEMINI_API_BASE_URL}/{GEMINI_MODEL}:generateContent",
+        headers={
+            "x-goog-api-key": api_key,
+            "Content-Type": "application/json",
+        },
+        json={
+            "contents": [
+                {
+                    "role": "user",
+                    "parts": [{"text": prompt}],
+                }
+            ],
+            "generationConfig": {
+                "temperature": 0.6,
+                "maxOutputTokens": max_tokens,
+                "responseMimeType": "application/json",
+            },
+        },
+    )
+    response.raise_for_status()
+    payload = response.json()
+    candidates = payload.get("candidates") or []
+    if not candidates:
+        raise ValueError(f"Gemini returned no candidates: {json.dumps(payload)}")
+
+    content = candidates[0].get("content") or {}
+    parts = content.get("parts") or []
+    text = "\n".join(
+        part.get("text", "") for part in parts if isinstance(part, dict) and part.get("text")
+    )
+    if not text.strip():
+        raise ValueError(f"Gemini returned no text payload: {json.dumps(payload)}")
+    return extract_json_object(text)
+
+
 async def with_retry(coro_factory, label: str) -> dict[str, Any]:
     last_error: Exception | None = None
     for attempt in range(3):
@@ -366,6 +408,21 @@ async def generate_openai_recommendations(
     return normalized
 
 
+async def generate_gemini_recommendations(
+    client: httpx.AsyncClient,
+    snapshot: dict[str, Any],
+    api_key: str,
+    existing_books: set[tuple[str, str]],
+) -> dict[str, Any]:
+    raw = await with_retry(
+        lambda: call_gemini_json(client, api_key, build_recommendations_prompt(snapshot), 2600),
+        "Gemini recommendations",
+    )
+    normalized = normalize_recommendations(raw, existing_books)
+    normalized["model"] = GEMINI_MODEL
+    return normalized
+
+
 def skip_generation(cache_payload: dict[str, Any], books_hash: str, force: bool) -> bool:
     if force or cache_payload.get("books_hash") != books_hash:
         return False
@@ -373,12 +430,14 @@ def skip_generation(cache_payload: dict[str, Any], books_hash: str, force: bool)
     recommendations = cache_payload.get("recommendations") or {}
     opus_model = (recommendations.get("opus") or {}).get("model")
     gpt_model = (recommendations.get("gpt45") or {}).get("model")
+    gemini_model = (recommendations.get("gemini") or {}).get("model")
     cache_dry_run = bool(cache_payload.get("dry_run"))
     prompt_hash = cache_payload.get("prompt_hash")
     return (
         cache_dry_run == LLM_DRY_RUN
         and opus_model == ANTHROPIC_MODEL
         and gpt_model == OPENAI_MODEL
+        and gemini_model == GEMINI_MODEL
         and prompt_hash == compute_prompt_hash()
     )
 
@@ -401,6 +460,7 @@ async def generate_cache_payload(
 
     anthropic_key = os.getenv("ANTHROPIC_API_KEY", "").strip()
     openai_key = os.getenv("OPENAI_API_KEY", "").strip()
+    gemini_key = os.getenv("GEMINI_API_KEY", "").strip() or os.getenv("GOOGLE_API_KEY", "").strip()
 
     result = default_llm_cache()
     result["books_hash"] = books_hash
@@ -409,6 +469,7 @@ async def generate_cache_payload(
     result["prompt_hash"] = compute_prompt_hash()
     result["recommendations"]["opus"]["model"] = ANTHROPIC_MODEL
     result["recommendations"]["gpt45"]["model"] = OPENAI_MODEL
+    result["recommendations"]["gemini"]["model"] = GEMINI_MODEL
 
     if LLM_DRY_RUN:
         result["taste_profile"] = build_mock_taste_profile()
@@ -417,6 +478,9 @@ async def generate_cache_payload(
         )
         result["recommendations"]["gpt45"] = build_mock_recommendations(
             OPENAI_MODEL, "OpenAI"
+        )
+        result["recommendations"]["gemini"] = build_mock_recommendations(
+            GEMINI_MODEL, "Gemini"
         )
         return result, False
 
@@ -440,6 +504,9 @@ async def generate_cache_payload(
             generate_openai_recommendations(client, snapshot, openai_key, all_books)
             if openai_key
             else None,
+            generate_gemini_recommendations(client, snapshot, gemini_key, all_books)
+            if gemini_key
+            else None,
         ]
 
         if recommendation_tasks[0] is None:
@@ -452,19 +519,28 @@ async def generate_cache_payload(
                 "model": OPENAI_MODEL,
                 "error": "OPENAI_API_KEY is not set.",
             }
+        if recommendation_tasks[2] is None:
+            result["recommendations"]["gemini"] = {
+                "model": GEMINI_MODEL,
+                "error": "GEMINI_API_KEY or GOOGLE_API_KEY is not set.",
+            }
 
         active_tasks = [task for task in recommendation_tasks if task is not None]
         responses = await asyncio.gather(*active_tasks, return_exceptions=True)
 
         response_index = 0
-        for provider_key, task in (("opus", recommendation_tasks[0]), ("gpt45", recommendation_tasks[1])):
+        for provider_key, task, model_name in (
+            ("opus", recommendation_tasks[0], ANTHROPIC_MODEL),
+            ("gpt45", recommendation_tasks[1], OPENAI_MODEL),
+            ("gemini", recommendation_tasks[2], GEMINI_MODEL),
+        ):
             if task is None:
                 continue
             response = responses[response_index]
             response_index += 1
             if isinstance(response, Exception):
                 result["recommendations"][provider_key] = {
-                    "model": ANTHROPIC_MODEL if provider_key == "opus" else OPENAI_MODEL,
+                    "model": model_name,
                     "error": str(response),
                 }
             else:
@@ -495,10 +571,12 @@ def _print_result(label: str, payload: dict[str, Any]) -> None:
     print(f"  books_hash: {payload.get('books_hash')}")
     print(f"  dry_run: {'true' if payload.get('dry_run') else 'false'}")
     print(f"  taste_profile: {'ok' if taste_ok else 'error'}")
+    recommendation_status = ", ".join(
+        f"{provider_key}={'ok' if (payload['recommendations'].get(provider_key) or {}).get('books') else 'error'}"
+        for provider_key in ("opus", "gpt45", "gemini")
+    )
     print(
-        "  recommendations: "
-        f"opus={'ok' if payload['recommendations']['opus'].get('books') else 'error'}, "
-        f"gpt45={'ok' if payload['recommendations']['gpt45'].get('books') else 'error'}"
+        f"  recommendations: {recommendation_status}"
     )
 
 

--- a/site/index.html
+++ b/site/index.html
@@ -398,7 +398,7 @@
 
     .recommendation-grid {
       display: grid;
-      grid-template-columns: repeat(2, minmax(0, 1fr));
+      grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
       gap: 18px;
     }
 
@@ -451,6 +451,17 @@
       border-radius: 18px;
       background: rgba(255, 252, 247, 0.74);
       padding: 16px;
+    }
+
+    .recommendation-empty {
+      margin-top: 14px;
+      padding: 18px 16px;
+      border: 1px dashed rgba(122, 92, 62, 0.24);
+      border-radius: 18px;
+      background: rgba(255, 252, 247, 0.58);
+      color: var(--muted);
+      font-size: .86rem;
+      line-height: 1.6;
     }
 
     .recommendation-meta {
@@ -1167,7 +1178,7 @@
     <div class="section-header">
       <div>
         <h2 class="section-heading">AI Picks</h2>
-        <p class="section-subtitle">Two models, one shelf, and a chance to see where they agree or diverge.</p>
+        <p class="section-subtitle">Three models, one shelf, and a chance to see where they agree or diverge.</p>
       </div>
     </div>
     <button class="collapsible-toggle" id="recommendations-toggle">
@@ -1587,44 +1598,58 @@ function renderRecommendations(recommendations) {
   const footer = document.getElementById('recommendation-footer');
 
   const providers = [
-    ['opus', 'Claude Opus', recommendations && recommendations.opus],
-    ['gpt45', 'GPT-4.5', recommendations && recommendations.gpt45],
+    ['opus', 'Claude', recommendations && recommendations.opus],
+    ['gpt45', 'ChatGPT', recommendations && recommendations.gpt45],
+    ['gemini', 'Gemini', recommendations && recommendations.gemini],
   ];
-  const available = providers.filter(([, , entry]) => entry && Array.isArray(entry.books) && entry.books.length);
   const unavailable = providers.filter(([, , entry]) => entry && entry.error);
 
-  if (!available.length) {
+  if (!recommendations) {
     section.classList.add('hidden');
     return;
   }
 
   section.classList.remove('hidden');
-  grid.classList.toggle('single', available.length === 1);
+  grid.classList.remove('single');
 
   if (unavailable.length === 1) {
     advisory.classList.remove('hidden');
     advisory.textContent = `${unavailable[0][1]} was unavailable when this set was last generated.`;
+  } else if (unavailable.length > 1) {
+    advisory.classList.remove('hidden');
+    advisory.textContent = `${unavailable.map(([, label]) => label).join(' and ')} were unavailable when this set was last generated.`;
   } else {
     advisory.classList.add('hidden');
     advisory.textContent = '';
   }
 
-  const overlap = new Set();
-  if (available.length === 2) {
-    const left = new Set(available[0][2].books.map(book => `${(book.title || '').toLowerCase()}::${(book.author || '').toLowerCase()}`));
-    available[1][2].books.forEach(book => {
+  const overlapCounts = new Map();
+  providers.forEach(([, , entry]) => {
+    ((entry && entry.books) || []).forEach(book => {
       const key = `${(book.title || '').toLowerCase()}::${(book.author || '').toLowerCase()}`;
-      if (left.has(key)) overlap.add(key);
+      overlapCounts.set(key, (overlapCounts.get(key) || 0) + 1);
     });
-  }
+  });
 
-  grid.innerHTML = available.map(([key, label, entry]) => `
+  grid.innerHTML = providers.map(([key, label, entry]) => {
+    const hasBooks = entry && Array.isArray(entry.books) && entry.books.length;
+    const modelLabel = entry && entry.model ? entry.model : 'not generated yet';
+    const reasoning = entry && entry.reasoning
+      ? entry.reasoning
+      : hasBooks
+        ? ''
+        : entry && entry.error
+          ? 'This provider did not return recommendations in the last generation.'
+          : 'Not generated yet. Run LLM regeneration to fill this column.';
+
+    return `
     <article class="recommendation-column">
       <div class="column-header">
         <div class="column-title">${escHtml(label)}</div>
-        <span class="chip">${escHtml(entry.model || 'unknown model')}</span>
+        <span class="chip">${escHtml(modelLabel)}</span>
       </div>
-      <p class="reasoning">${escHtml(entry.reasoning || '')}</p>
+      <p class="reasoning">${escHtml(reasoning)}</p>
+      ${hasBooks ? `
       <div class="recommendation-list">
         ${(entry.books || []).map(book => {
           const bookKey = `${(book.title || '').toLowerCase()}::${(book.author || '').toLowerCase()}`;
@@ -1636,7 +1661,7 @@ function renderRecommendations(recommendations) {
                   <div class="recommendation-author">${escHtml(book.author)}</div>
                 </div>
                 <div class="recommendation-badges">
-                  ${overlap.has(bookKey) ? '<span class="agree-badge">Both agree</span>' : ''}
+                  ${(overlapCounts.get(bookKey) || 0) > 1 ? '<span class="agree-badge">Shared pick</span>' : ''}
                   ${book.from_to_read ? '<span class="to-read-badge">On your list</span>' : ''}
                   <span class="confidence-badge ${escHtml((book.confidence || 'medium').toLowerCase())}">${escHtml(book.confidence || 'medium')}</span>
                 </div>
@@ -1646,8 +1671,16 @@ function renderRecommendations(recommendations) {
           `;
         }).join('')}
       </div>
+      ` : `
+      <div class="recommendation-empty">
+        ${entry && entry.error
+          ? 'Unavailable in the last cached generation.'
+          : 'Not generated yet.'}
+      </div>
+      `}
     </article>
-  `).join('');
+  `;
+  }).join('');
 
   const generatedAt = healthPayload && (healthPayload.llm_generated_at || healthPayload.generated_at);
   footer.textContent = generatedAt

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -55,6 +55,11 @@ class ApiTests(unittest.TestCase):
                             "reasoning": "Strategy",
                         },
                         "gpt45": {"model": "gpt-test", "error": "temporarily unavailable"},
+                        "gemini": {
+                            "model": "gemini-test",
+                            "books": [{"title": "Rec G", "author": "Author G", "reason": "Specific Gemini.", "confidence": "medium"}],
+                            "reasoning": "Gemini strategy",
+                        },
                     },
                 }
             ),
@@ -95,6 +100,7 @@ class ApiTests(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         payload = response.json()
         self.assertIn("opus", payload)
+        self.assertIn("gemini", payload)
         self.assertEqual(payload["opus"]["books"][0]["title"], "Rec A")
 
     def test_health_endpoint_prefers_llm_timestamp(self):

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -157,6 +157,18 @@ SAMPLE_LLM_CACHE = {
             "reasoning": "Sci-fi lover strategy.",
         },
         "gpt45": {"model": "gpt-test", "error": "unavailable"},
+        "gemini": {
+            "model": "gemini-test",
+            "books": [
+                {
+                    "title": "The Left Hand of Darkness",
+                    "author": "Ursula K. Le Guin",
+                    "reason": "Thoughtful speculative fiction.",
+                    "confidence": "medium",
+                }
+            ],
+            "reasoning": "Leans toward reflective science fiction.",
+        },
     },
 }
 
@@ -428,6 +440,7 @@ class BookshelfDBTests(unittest.TestCase):
         recs = self.db_store.recommendations()
         self.assertIsNotNone(recs)
         self.assertIn("opus", recs)
+        self.assertIn("gemini", recs)
         self.assertEqual(recs["opus"]["books"][0]["title"], "Foundation")
 
     def test_health_returns_expected_keys(self):
@@ -557,6 +570,7 @@ class ApiSqliteTests(unittest.TestCase):
         resp = self.client.get("/api/recommendations")
         self.assertEqual(resp.status_code, 200)
         self.assertIn("opus", resp.json())
+        self.assertIn("gemini", resp.json())
 
     def test_health_endpoint(self):
         resp = self.client.get("/api/health")

--- a/tests/test_generate_llm.py
+++ b/tests/test_generate_llm.py
@@ -69,6 +69,7 @@ class GenerateLlmTests(unittest.TestCase):
         cache_payload["prompt_hash"] = generate_llm.compute_prompt_hash()
         cache_payload["recommendations"]["opus"]["model"] = generate_llm.ANTHROPIC_MODEL
         cache_payload["recommendations"]["gpt45"]["model"] = generate_llm.OPENAI_MODEL
+        cache_payload["recommendations"]["gemini"]["model"] = generate_llm.GEMINI_MODEL
         self.assertTrue(generate_llm.skip_generation(cache_payload, books_hash, force=False))
         self.assertFalse(generate_llm.skip_generation(cache_payload, books_hash, force=True))
 
@@ -80,6 +81,7 @@ class GenerateLlmTests(unittest.TestCase):
         cache_payload["prompt_hash"] = generate_llm.compute_prompt_hash()
         cache_payload["recommendations"]["opus"]["model"] = "old-anthropic-model"
         cache_payload["recommendations"]["gpt45"]["model"] = "old-openai-model"
+        cache_payload["recommendations"]["gemini"]["model"] = "old-gemini-model"
 
         self.assertFalse(generate_llm.skip_generation(cache_payload, books_hash, force=False))
 
@@ -91,6 +93,7 @@ class GenerateLlmTests(unittest.TestCase):
         cache_payload["prompt_hash"] = "old-prompt-hash"
         cache_payload["recommendations"]["opus"]["model"] = generate_llm.ANTHROPIC_MODEL
         cache_payload["recommendations"]["gpt45"]["model"] = generate_llm.OPENAI_MODEL
+        cache_payload["recommendations"]["gemini"]["model"] = generate_llm.GEMINI_MODEL
 
         self.assertFalse(generate_llm.skip_generation(cache_payload, books_hash, force=False))
 
@@ -109,7 +112,15 @@ class GenerateLlmTests(unittest.TestCase):
                 return False
 
         with (
-            patch.dict(os.environ, {"ANTHROPIC_API_KEY": "test-key", "OPENAI_API_KEY": "test-key"}, clear=False),
+            patch.dict(
+                os.environ,
+                {
+                    "ANTHROPIC_API_KEY": "test-key",
+                    "OPENAI_API_KEY": "test-key",
+                    "GEMINI_API_KEY": "test-key",
+                },
+                clear=False,
+            ),
             patch.object(generate_llm.httpx, "Timeout", return_value=None),
             patch.object(generate_llm.httpx, "AsyncClient", FakeAsyncClient),
             patch.object(
@@ -127,6 +138,11 @@ class GenerateLlmTests(unittest.TestCase):
                 "generate_openai_recommendations",
                 AsyncMock(return_value={"model": "gpt-test", "books": [{"title": "Rec", "author": "Author", "reason": "Specific.", "confidence": "high"}], "reasoning": "Pattern-driven."}),
             ),
+            patch.object(
+                generate_llm,
+                "generate_gemini_recommendations",
+                AsyncMock(return_value={"model": "gemini-test", "books": [{"title": "Rec 2", "author": "Author 2", "reason": "Specific 2.", "confidence": "medium"}], "reasoning": "Another pattern-driven view."}),
+            ),
         ):
             payload, skipped = asyncio.run(
                 generate_llm.generate_cache_payload(books_payload, cache_payload, force=False)
@@ -134,6 +150,7 @@ class GenerateLlmTests(unittest.TestCase):
 
         self.assertFalse(skipped)
         self.assertEqual(payload["recommendations"]["gpt45"]["model"], "gpt-test")
+        self.assertEqual(payload["recommendations"]["gemini"]["model"], "gemini-test")
         self.assertIn("error", payload["recommendations"]["opus"])
         self.assertEqual(payload["taste_profile"]["summary"], "Sharp.")
         self.assertFalse(payload["dry_run"])
@@ -147,6 +164,7 @@ class GenerateLlmTests(unittest.TestCase):
             patch.object(generate_llm, "generate_taste_profile", AsyncMock(side_effect=AssertionError("should not call providers"))),
             patch.object(generate_llm, "generate_anthropic_recommendations", AsyncMock(side_effect=AssertionError("should not call providers"))),
             patch.object(generate_llm, "generate_openai_recommendations", AsyncMock(side_effect=AssertionError("should not call providers"))),
+            patch.object(generate_llm, "generate_gemini_recommendations", AsyncMock(side_effect=AssertionError("should not call providers"))),
         ):
             payload, skipped = asyncio.run(
                 generate_llm.generate_cache_payload(books_payload, cache_payload, force=False)
@@ -157,6 +175,7 @@ class GenerateLlmTests(unittest.TestCase):
         self.assertEqual(payload["taste_profile"]["summary"], "[DRY RUN] Mock taste profile")
         self.assertEqual(payload["recommendations"]["opus"]["books"][0]["title"], "[DRY RUN] Anthropic Pick 1")
         self.assertEqual(payload["recommendations"]["gpt45"]["books"][0]["title"], "[DRY RUN] OpenAI Pick 1")
+        self.assertEqual(payload["recommendations"]["gemini"]["books"][0]["title"], "[DRY RUN] Gemini Pick 1")
 
     def test_main_persists_generated_cache(self):
         books_payload = sample_books_payload()
@@ -178,6 +197,11 @@ class GenerateLlmTests(unittest.TestCase):
                 "model": "gpt-test",
                 "books": [{"title": "Rec", "author": "Author", "reason": "Specific.", "confidence": "high"}],
                 "reasoning": "Reasoning",
+            }
+            fake_payload["recommendations"]["gemini"] = {
+                "model": "gemini-test",
+                "books": [{"title": "Rec 2", "author": "Author 2", "reason": "Specific 2.", "confidence": "medium"}],
+                "reasoning": "Reasoning 2",
             }
 
             with patch.object(
@@ -203,6 +227,7 @@ class GenerateLlmTests(unittest.TestCase):
             saved = load_json(cache_path, default_llm_cache)
             self.assertEqual(saved["books_hash"], "abc123")
             self.assertEqual(saved["recommendations"]["gpt45"]["model"], "gpt-test")
+            self.assertEqual(saved["recommendations"]["gemini"]["model"], "gemini-test")
 
 
     def test_build_library_snapshot_includes_notes(self):
@@ -267,6 +292,11 @@ class GenerateLlmTests(unittest.TestCase):
                 "model": "gpt-test",
                 "books": [{"title": "Rec", "author": "Author", "reason": "Specific.", "confidence": "high"}],
                 "reasoning": "Reasoning",
+            }
+            fake_payload["recommendations"]["gemini"] = {
+                "model": "gemini-test",
+                "books": [{"title": "Rec 2", "author": "Author 2", "reason": "Specific 2.", "confidence": "medium"}],
+                "reasoning": "Reasoning 2",
             }
 
             with patch.object(


### PR DESCRIPTION
Refs #4

## What changed
- added Gemini as a third recommendation provider alongside Claude and ChatGPT
- extended the cache shape and generator flow to carry a `gemini` recommendation payload
- updated the AI Picks UI to render a three-column layout and show a placeholder column when a provider has not generated data yet
- updated tests and docs for the new provider and env settings

## Why
Issue #4 asks for a third opinion in AI Picks so the recommendation panel can compare Claude, ChatGPT, and Gemini side by side.

## Notes
- production deploy and regeneration showed Claude and ChatGPT succeeding, while Gemini currently fails on malformed JSON from the model response
- this PR captures the product and plumbing changes first; Gemini response hardening is a follow-up fix

## Validation
- `./.venv/bin/python tests/test_generate_llm.py`
- `./.venv/bin/python tests/test_api.py`
- `./.venv/bin/python tests/test_db.py`
