### PR TITLE
[codex] Add tag picker to book forms

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -63,6 +63,32 @@ def _auth(request: Request) -> None:
     verify_auth(request, conn)
 
 
+def _normalize_shelf_tag(value: str) -> str:
+    shelf = (value or "").strip()
+    return {
+        "to_read": "to-read",
+        "currently_reading": "currently-reading",
+    }.get(shelf, shelf)
+
+
+def _normalize_shelves(value: object) -> list[str]:
+    if not isinstance(value, list):
+        return []
+
+    normalized: list[str] = []
+    seen: set[str] = set()
+    for raw in value:
+        tag = _normalize_shelf_tag(str(raw or "").strip())
+        if not tag:
+            continue
+        key = tag.casefold()
+        if key in seen:
+            continue
+        seen.add(key)
+        normalized.append(tag)
+    return normalized
+
+
 # ── LLM regeneration state ──────────────────────────────────────────────────
 _llm_lock = asyncio.Lock()
 _llm_status: dict = {"status": "idle"}
@@ -158,6 +184,7 @@ async def create_book(request: Request) -> dict:
     from db import insert_book
 
     shelf = body.get("exclusive_shelf", "to_read")
+    shelves = _normalize_shelves(body.get("shelves"))
     book_data = {
         "title": title,
         "author": author,
@@ -167,7 +194,7 @@ async def create_book(request: Request) -> dict:
         "pages": body.get("pages"),
         "date_read": body.get("date_read") or None,
         "date_added": body.get("date_added") or utc_now_iso()[:10],
-        "shelves": body.get("shelves", [shelf]),
+        "shelves": shelves or [_normalize_shelf_tag(shelf)],
         "exclusive_shelf": shelf,
         "review": body.get("my_review") or body.get("review") or None,
         "notes": body.get("notes") or None,
@@ -199,6 +226,9 @@ async def update_book_endpoint(book_id: int, request: Request) -> dict:
     body = await request.json()
     if not body:
         raise HTTPException(status_code=422, detail="No fields to update.")
+
+    if "shelves" in body:
+        body["shelves"] = _normalize_shelves(body.get("shelves"))
 
     if not update_book(store.conn(), book_id, body):
         raise HTTPException(status_code=404, detail="Book not found.")

--- a/site/add.html
+++ b/site/add.html
@@ -55,9 +55,47 @@
     .btn-primary { background: var(--accent-deep); color: #fff; }
     .btn-primary:hover { background: var(--accent); transform: translateY(-1px); }
     .btn-primary:disabled { opacity: 0.5; cursor: not-allowed; transform: none; }
+    .hidden { display: none; }
     .message { padding: 12px; border-radius: 10px; font-size: .85rem; }
     .message.success { background: var(--olive-soft); color: var(--olive); border: 1px solid rgba(94,105,84,0.2); }
     .message.error { background: rgba(140,93,88,0.1); color: #8c5d58; border: 1px solid rgba(140,93,88,0.2); }
+    .tag-picker { display: grid; gap: 10px; padding: 12px; border: 1px solid var(--border); border-radius: 12px; background: rgba(255,255,255,0.58); }
+    .tag-selected, .tag-suggestions { display: flex; flex-wrap: wrap; gap: 8px; }
+    .tag-placeholder, .tag-help { font-size: .78rem; color: var(--muted); }
+    .tag-input-row { display: flex; gap: 8px; }
+    .tag-input-row input { flex: 1; }
+    .tag-chip, .tag-suggestion {
+      display: inline-flex; align-items: center; gap: 6px; border-radius: 999px;
+      border: 1px solid var(--border); background: rgba(255,255,255,0.88);
+      padding: 6px 10px; font-size: .78rem; line-height: 1; color: var(--text);
+    }
+    .tag-chip button, .tag-suggestion {
+      font: inherit; cursor: pointer;
+    }
+    .tag-chip button {
+      border: none; background: none; color: var(--muted); padding: 0; line-height: 1;
+    }
+    .tag-chip button:hover { color: var(--accent-deep); }
+    .tag-suggestion {
+      background: var(--accent-soft);
+      border-color: rgba(122,92,62,0.22);
+    }
+    .tag-suggestion:hover {
+      background: rgba(122,92,62,0.18);
+      border-color: var(--border-strong);
+    }
+    .tag-add-btn {
+      border: 1px solid var(--border);
+      border-radius: 10px;
+      background: rgba(255,255,255,0.85);
+      color: var(--accent-deep);
+      font: inherit;
+      font-size: .82rem;
+      font-weight: 600;
+      padding: 0 14px;
+      cursor: pointer;
+    }
+    .tag-add-btn:hover { background: var(--accent-soft); }
   </style>
 </head>
 <body>
@@ -105,6 +143,22 @@
           <option value="4">4 stars</option>
           <option value="5">5 stars</option>
         </select>
+      </div>
+    </div>
+
+    <div class="form-group">
+      <label for="tag-input">Tags</label>
+      <div class="tag-picker">
+        <div class="tag-selected" id="selected-tags">
+          <span class="tag-placeholder">No custom tags yet.</span>
+        </div>
+        <div class="tag-input-row">
+          <input type="text" id="tag-input" list="tag-options" placeholder="Type a tag and press Enter">
+          <button type="button" class="tag-add-btn" id="add-tag-btn">Add</button>
+        </div>
+        <datalist id="tag-options"></datalist>
+        <div class="tag-help">Pick from existing tags below or create a new one. Shelf tags are added automatically.</div>
+        <div class="tag-suggestions" id="tag-suggestions"></div>
       </div>
     </div>
 
@@ -156,9 +210,115 @@ const AUTH_KEY = 'bookshelf_auth_token';
 const isLocalHost = location.hostname === 'localhost' || location.hostname === '127.0.0.1';
 const localApiPort = location.port === '8010' ? '8011' : '8001';
 const apiBase = isLocalHost ? `http://127.0.0.1:${localApiPort}` : '';
+const RESERVED_SHELF_TAGS = new Set(['read', 'currently-reading', 'to-read']);
+const tagState = { selected: [], suggestions: [] };
 
 function getToken() { return localStorage.getItem(AUTH_KEY) || ''; }
 function escHtml(s) { const d = document.createElement('div'); d.textContent = s; return d.innerHTML; }
+function normalizeShelfTag(value) {
+  if (value === 'to_read') return 'to-read';
+  if (value === 'currently_reading') return 'currently-reading';
+  return value;
+}
+function normalizeTag(value) {
+  const trimmed = String(value || '').trim().replace(/\s+/g, ' ');
+  if (!trimmed) return '';
+  return normalizeShelfTag(trimmed);
+}
+function tagKey(value) { return normalizeTag(value).toLocaleLowerCase(); }
+function isReservedShelfTag(value) { return RESERVED_SHELF_TAGS.has(normalizeTag(value)); }
+function dedupeTags(tags, excludeReserved = false) {
+  const seen = new Set();
+  const normalized = [];
+  tags.forEach(raw => {
+    const tag = normalizeTag(raw);
+    if (!tag) return;
+    if (excludeReserved && isReservedShelfTag(tag)) return;
+    const key = tagKey(tag);
+    if (seen.has(key)) return;
+    seen.add(key);
+    normalized.push(tag);
+  });
+  return normalized;
+}
+function buildSubmittedShelves(exclusiveShelf) {
+  return dedupeTags([normalizeShelfTag(exclusiveShelf), ...tagState.selected]);
+}
+function renderTagOptions() {
+  document.getElementById('tag-options').innerHTML = tagState.suggestions
+    .map(tag => `<option value="${escHtml(tag)}"></option>`)
+    .join('');
+}
+function renderSelectedTags() {
+  const el = document.getElementById('selected-tags');
+  if (!tagState.selected.length) {
+    el.innerHTML = '<span class="tag-placeholder">No custom tags yet.</span>';
+    return;
+  }
+  el.innerHTML = tagState.selected.map(tag => `
+    <span class="tag-chip">
+      <span>${escHtml(tag)}</span>
+      <button type="button" data-remove-tag="${escHtml(tag)}" aria-label="Remove ${escHtml(tag)}">&times;</button>
+    </span>
+  `).join('');
+}
+function renderTagSuggestions() {
+  const selected = new Set(tagState.selected.map(tagKey));
+  const suggestions = tagState.suggestions.filter(tag => !selected.has(tagKey(tag))).slice(0, 40);
+  document.getElementById('tag-suggestions').innerHTML = suggestions.map(tag => `
+    <button type="button" class="tag-suggestion" data-add-tag="${escHtml(tag)}">${escHtml(tag)}</button>
+  `).join('');
+}
+function setSelectedTags(tags) {
+  tagState.selected = dedupeTags(tags, true);
+  renderSelectedTags();
+  renderTagSuggestions();
+}
+function addTag(rawTag) {
+  const tag = normalizeTag(rawTag);
+  if (!tag || isReservedShelfTag(tag)) return false;
+  tagState.selected = dedupeTags([...tagState.selected, tag], true);
+  renderSelectedTags();
+  renderTagSuggestions();
+  return true;
+}
+function removeTag(rawTag) {
+  const key = tagKey(rawTag);
+  tagState.selected = tagState.selected.filter(tag => tagKey(tag) !== key);
+  renderSelectedTags();
+  renderTagSuggestions();
+}
+function extractTagSuggestions(books) {
+  const counts = new Map();
+  books.forEach(book => (book.shelves || []).forEach(rawTag => {
+    const tag = normalizeTag(rawTag);
+    if (!tag || isReservedShelfTag(tag)) return;
+    const key = tagKey(tag);
+    const entry = counts.get(key) || { tag, count: 0 };
+    entry.count += 1;
+    counts.set(key, entry);
+  }));
+  return Array.from(counts.values())
+    .sort((a, b) => b.count - a.count || a.tag.localeCompare(b.tag))
+    .map(entry => entry.tag);
+}
+async function loadTagSuggestions() {
+  try {
+    const resp = await fetch(`${apiBase}/api/books`);
+    if (!resp.ok) return;
+    const data = await resp.json();
+    const allBooks = [
+      ...(data.books.read || []),
+      ...(data.books.currently_reading || []),
+      ...(data.books.to_read || []),
+    ];
+    tagState.suggestions = extractTagSuggestions(allBooks);
+    renderTagOptions();
+    renderTagSuggestions();
+  } catch (err) {
+    // Tag suggestions are a convenience; failures should not block the form.
+  }
+}
 
 function showMessage(text, type) {
   const el = document.getElementById('message');
@@ -215,6 +375,31 @@ document.getElementById('lookup-query').addEventListener('keydown', e => {
   if (e.key === 'Enter') { e.preventDefault(); document.getElementById('lookup-btn').click(); }
 });
 
+document.getElementById('add-tag-btn').addEventListener('click', () => {
+  const input = document.getElementById('tag-input');
+  if (addTag(input.value)) input.value = '';
+  input.focus();
+});
+
+document.getElementById('tag-input').addEventListener('keydown', e => {
+  if (e.key !== 'Enter' && e.key !== ',') return;
+  e.preventDefault();
+  const input = document.getElementById('tag-input');
+  if (addTag(input.value)) input.value = '';
+});
+
+document.getElementById('selected-tags').addEventListener('click', e => {
+  const btn = e.target.closest('[data-remove-tag]');
+  if (!btn) return;
+  removeTag(btn.dataset.removeTag);
+});
+
+document.getElementById('tag-suggestions').addEventListener('click', e => {
+  const btn = e.target.closest('[data-add-tag]');
+  if (!btn) return;
+  addTag(btn.dataset.addTag);
+});
+
 // ── Toggle expanded ──
 document.getElementById('toggle-expanded').addEventListener('click', function() {
   const fields = document.getElementById('expanded-fields');
@@ -237,6 +422,7 @@ document.getElementById('add-form').addEventListener('submit', async e => {
     author: document.getElementById('author').value.trim(),
     exclusive_shelf: document.getElementById('exclusive_shelf').value,
     my_rating: parseInt(document.getElementById('my_rating').value) || 0,
+    shelves: buildSubmittedShelves(document.getElementById('exclusive_shelf').value),
   };
 
   // Optional expanded fields
@@ -275,6 +461,9 @@ document.getElementById('add-form').addEventListener('submit', async e => {
     btn.textContent = 'Add Book';
   }
 });
+
+setSelectedTags([]);
+loadTagSuggestions();
 </script>
 </body>
 </html>

--- a/site/edit.html
+++ b/site/edit.html
@@ -47,6 +47,43 @@
     .message { padding: 12px; border-radius: 10px; font-size: .85rem; }
     .message.success { background: var(--olive-soft); color: var(--olive); border: 1px solid rgba(94,105,84,0.2); }
     .message.error { background: var(--danger-soft); color: var(--danger); border: 1px solid rgba(140,93,88,0.2); }
+    .tag-picker { display: grid; gap: 10px; padding: 12px; border: 1px solid var(--border); border-radius: 12px; background: rgba(255,255,255,0.58); }
+    .tag-selected, .tag-suggestions { display: flex; flex-wrap: wrap; gap: 8px; }
+    .tag-placeholder, .tag-help { font-size: .78rem; color: var(--muted); }
+    .tag-input-row { display: flex; gap: 8px; }
+    .tag-input-row input { flex: 1; }
+    .tag-chip, .tag-suggestion {
+      display: inline-flex; align-items: center; gap: 6px; border-radius: 999px;
+      border: 1px solid var(--border); background: rgba(255,255,255,0.88);
+      padding: 6px 10px; font-size: .78rem; line-height: 1; color: var(--text);
+    }
+    .tag-chip button, .tag-suggestion {
+      font: inherit; cursor: pointer;
+    }
+    .tag-chip button {
+      border: none; background: none; color: var(--muted); padding: 0; line-height: 1;
+    }
+    .tag-chip button:hover { color: var(--accent-deep); }
+    .tag-suggestion {
+      background: var(--accent-soft);
+      border-color: rgba(122,92,62,0.22);
+    }
+    .tag-suggestion:hover {
+      background: rgba(122,92,62,0.18);
+      border-color: var(--border-strong);
+    }
+    .tag-add-btn {
+      border: 1px solid var(--border);
+      border-radius: 10px;
+      background: rgba(255,255,255,0.85);
+      color: var(--accent-deep);
+      font: inherit;
+      font-size: .82rem;
+      font-weight: 600;
+      padding: 0 14px;
+      cursor: pointer;
+    }
+    .tag-add-btn:hover { background: var(--accent-soft); }
     .hidden { display: none; }
     .loading { text-align: center; padding: 48px; color: var(--muted); }
   </style>
@@ -89,6 +126,22 @@
           <option value="4">4 stars</option>
           <option value="5">5 stars</option>
         </select>
+      </div>
+    </div>
+
+    <div class="form-group">
+      <label for="tag-input">Tags</label>
+      <div class="tag-picker">
+        <div class="tag-selected" id="selected-tags">
+          <span class="tag-placeholder">No custom tags yet.</span>
+        </div>
+        <div class="tag-input-row">
+          <input type="text" id="tag-input" list="tag-options" placeholder="Type a tag and press Enter">
+          <button type="button" class="tag-add-btn" id="add-tag-btn">Add</button>
+        </div>
+        <datalist id="tag-options"></datalist>
+        <div class="tag-help">Pick from existing tags below or create a new one. Shelf tags are added automatically.</div>
+        <div class="tag-suggestions" id="tag-suggestions"></div>
       </div>
     </div>
 
@@ -145,11 +198,101 @@ const AUTH_KEY = 'bookshelf_auth_token';
 const isLocalHost = location.hostname === 'localhost' || location.hostname === '127.0.0.1';
 const localApiPort = location.port === '8010' ? '8011' : '8001';
 const apiBase = isLocalHost ? `http://127.0.0.1:${localApiPort}` : '';
+const RESERVED_SHELF_TAGS = new Set(['read', 'currently-reading', 'to-read']);
+const tagState = { selected: [], suggestions: [] };
 
 const params = new URLSearchParams(location.search);
 const bookId = params.get('id');
 
 function getToken() { return localStorage.getItem(AUTH_KEY) || ''; }
+function escHtml(s) { const d = document.createElement('div'); d.textContent = s; return d.innerHTML; }
+function normalizeShelfTag(value) {
+  if (value === 'to_read') return 'to-read';
+  if (value === 'currently_reading') return 'currently-reading';
+  return value;
+}
+function normalizeTag(value) {
+  const trimmed = String(value || '').trim().replace(/\s+/g, ' ');
+  if (!trimmed) return '';
+  return normalizeShelfTag(trimmed);
+}
+function tagKey(value) { return normalizeTag(value).toLocaleLowerCase(); }
+function isReservedShelfTag(value) { return RESERVED_SHELF_TAGS.has(normalizeTag(value)); }
+function dedupeTags(tags, excludeReserved = false) {
+  const seen = new Set();
+  const normalized = [];
+  tags.forEach(raw => {
+    const tag = normalizeTag(raw);
+    if (!tag) return;
+    if (excludeReserved && isReservedShelfTag(tag)) return;
+    const key = tagKey(tag);
+    if (seen.has(key)) return;
+    seen.add(key);
+    normalized.push(tag);
+  });
+  return normalized;
+}
+function buildSubmittedShelves(exclusiveShelf) {
+  return dedupeTags([normalizeShelfTag(exclusiveShelf), ...tagState.selected]);
+}
+function renderTagOptions() {
+  document.getElementById('tag-options').innerHTML = tagState.suggestions
+    .map(tag => `<option value="${escHtml(tag)}"></option>`)
+    .join('');
+}
+function renderSelectedTags() {
+  const el = document.getElementById('selected-tags');
+  if (!tagState.selected.length) {
+    el.innerHTML = '<span class="tag-placeholder">No custom tags yet.</span>';
+    return;
+  }
+  el.innerHTML = tagState.selected.map(tag => `
+    <span class="tag-chip">
+      <span>${escHtml(tag)}</span>
+      <button type="button" data-remove-tag="${escHtml(tag)}" aria-label="Remove ${escHtml(tag)}">&times;</button>
+    </span>
+  `).join('');
+}
+function renderTagSuggestions() {
+  const selected = new Set(tagState.selected.map(tagKey));
+  const suggestions = tagState.suggestions.filter(tag => !selected.has(tagKey(tag))).slice(0, 40);
+  document.getElementById('tag-suggestions').innerHTML = suggestions.map(tag => `
+    <button type="button" class="tag-suggestion" data-add-tag="${escHtml(tag)}">${escHtml(tag)}</button>
+  `).join('');
+}
+function setSelectedTags(tags) {
+  tagState.selected = dedupeTags(tags, true);
+  renderSelectedTags();
+  renderTagSuggestions();
+}
+function addTag(rawTag) {
+  const tag = normalizeTag(rawTag);
+  if (!tag || isReservedShelfTag(tag)) return false;
+  tagState.selected = dedupeTags([...tagState.selected, tag], true);
+  renderSelectedTags();
+  renderTagSuggestions();
+  return true;
+}
+function removeTag(rawTag) {
+  const key = tagKey(rawTag);
+  tagState.selected = tagState.selected.filter(tag => tagKey(tag) !== key);
+  renderSelectedTags();
+  renderTagSuggestions();
+}
+function extractTagSuggestions(books) {
+  const counts = new Map();
+  books.forEach(book => (book.shelves || []).forEach(rawTag => {
+    const tag = normalizeTag(rawTag);
+    if (!tag || isReservedShelfTag(tag)) return;
+    const key = tagKey(tag);
+    const entry = counts.get(key) || { tag, count: 0 };
+    entry.count += 1;
+    counts.set(key, entry);
+  }));
+  return Array.from(counts.values())
+    .sort((a, b) => b.count - a.count || a.tag.localeCompare(b.tag))
+    .map(entry => entry.tag);
+}
 
 function showMessage(text, type) {
   const el = document.getElementById('message');
@@ -171,6 +314,7 @@ function populateForm(book) {
   document.getElementById('my_review').value = book.my_review || '';
   document.getElementById('notes').value = book.notes || '';
   document.getElementById('google_books_id').value = book.google_books_id || '';
+  setSelectedTags(book.shelves || []);
 }
 
 async function loadBook() {
@@ -186,6 +330,8 @@ async function loadBook() {
       ...(data.books.currently_reading || []),
       ...(data.books.to_read || []),
     ];
+    tagState.suggestions = extractTagSuggestions(allBooks);
+    renderTagOptions();
     const book = allBooks.find(b => String(b.id) === bookId);
     if (!book) {
       document.getElementById('loading').textContent = 'Book not found.';
@@ -214,6 +360,7 @@ document.getElementById('edit-form').addEventListener('submit', async e => {
     author: document.getElementById('author').value.trim(),
     exclusive_shelf: document.getElementById('exclusive_shelf').value,
     my_rating: parseInt(document.getElementById('my_rating').value) || 0,
+    shelves: buildSubmittedShelves(document.getElementById('exclusive_shelf').value),
   };
 
   const isbn13 = document.getElementById('isbn13').value.trim();
@@ -251,6 +398,33 @@ document.getElementById('edit-form').addEventListener('submit', async e => {
     btn.textContent = 'Save Changes';
   }
 });
+
+document.getElementById('add-tag-btn').addEventListener('click', () => {
+  const input = document.getElementById('tag-input');
+  if (addTag(input.value)) input.value = '';
+  input.focus();
+});
+
+document.getElementById('tag-input').addEventListener('keydown', e => {
+  if (e.key !== 'Enter' && e.key !== ',') return;
+  e.preventDefault();
+  const input = document.getElementById('tag-input');
+  if (addTag(input.value)) input.value = '';
+});
+
+document.getElementById('selected-tags').addEventListener('click', e => {
+  const btn = e.target.closest('[data-remove-tag]');
+  if (!btn) return;
+  removeTag(btn.dataset.removeTag);
+});
+
+document.getElementById('tag-suggestions').addEventListener('click', e => {
+  const btn = e.target.closest('[data-add-tag]');
+  if (!btn) return;
+  addTag(btn.dataset.addTag);
+});
+
+setSelectedTags([]);
 
 // Delete
 document.getElementById('delete-btn').addEventListener('click', async () => {

--- a/site/index.html
+++ b/site/index.html
@@ -1485,7 +1485,7 @@ function renderReadGrid() {
 
 function buildShelfTags(books) {
   const counts = {};
-  const excluded = new Set(['read', 'currently-reading', 'to-read']);
+  const excluded = new Set(['read', 'currently-reading', 'to-read', 'currently_reading', 'to_read']);
   books.forEach(book => (book.shelves || []).forEach(shelf => {
     if (excluded.has(shelf)) return;
     counts[shelf] = (counts[shelf] || 0) + 1;

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -597,6 +597,7 @@ class ApiSqliteTests(unittest.TestCase):
         data = resp.json()
         self.assertEqual(data["title"], "New Book")
         self.assertEqual(data["author"], "New Author")
+        self.assertEqual(data["shelves"], ["to-read"])
 
     def test_create_book_requires_auth(self):
         resp = self.client.post(
@@ -629,6 +630,22 @@ class ApiSqliteTests(unittest.TestCase):
         )
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(resp.json()["title"], "New Title")
+
+    def test_update_book_normalizes_shelves(self):
+        resp = self.client.post(
+            "/api/books",
+            json={"title": "Tagged Book", "author": "Author", "exclusive_shelf": "to_read"},
+            headers=TEST_AUTH_HEADER,
+        )
+        book_id = resp.json()["id"]
+
+        resp = self.client.put(
+            f"/api/books/{book_id}",
+            json={"shelves": ["to_read", "favorite", "favorite"]},
+            headers=TEST_AUTH_HEADER,
+        )
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json()["shelves"], ["to-read", "favorite"])
 
     def test_update_book_not_found(self):
         resp = self.client.put(


### PR DESCRIPTION
## Summary
- add a tag picker to the add and edit book forms
- submit manual book tags through the existing `shelves` field
- normalize shelf tags and filter out underscore variants from homepage tag suggestions

## Why
Goodreads-imported books already carried rich tags in `shelves`, and the homepage displayed and filtered them, but manual add/edit flows only exposed the exclusive shelf. This made imported tags visible but impossible to manage manually.

## Impact
Manual books and edited books now use the same tag model as imported books, and existing library tags can be reused directly from the form UI.

## Validation
- `./.venv/bin/python -m unittest tests.test_db.ApiSqliteTests.test_create_book tests.test_db.ApiSqliteTests.test_update_book tests.test_db.ApiSqliteTests.test_update_book_normalizes_shelves`

Closes #11
