### PR TITLE
Add Reading Life in Weeks grid visualization

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -1038,6 +1038,170 @@
       }
       .taste-summary { max-width: none; }
     }
+
+    /* ── Reading Life in Weeks ── */
+    .weeks-controls {
+      display: flex;
+      align-items: center;
+      gap: 16px;
+      flex-wrap: wrap;
+      margin-bottom: 16px;
+    }
+
+    .weeks-mode-toggle {
+      display: inline-flex;
+      border: 1px solid var(--border);
+      border-radius: 999px;
+      overflow: hidden;
+      background: rgba(255, 255, 255, 0.68);
+    }
+
+    .weeks-mode-toggle .pill {
+      border: none;
+      border-radius: 0;
+      margin: 0;
+    }
+
+    .weeks-mode-toggle .pill + .pill {
+      border-left: 1px solid var(--border);
+    }
+
+    .weeks-legend {
+      display: flex;
+      gap: 12px;
+      flex-wrap: wrap;
+      align-items: center;
+      font-size: .72rem;
+      color: var(--muted);
+    }
+
+    .weeks-legend-item {
+      display: inline-flex;
+      align-items: center;
+      gap: 4px;
+    }
+
+    .weeks-legend-swatch {
+      display: inline-block;
+      width: 10px;
+      height: 10px;
+      border-radius: 2px;
+    }
+
+    .weeks-grid-wrap {
+      overflow: hidden;
+      width: 100%;
+      margin-bottom: 12px;
+    }
+
+    .weeks-grid-wrap svg {
+      display: block;
+      width: 100%;
+      height: auto;
+    }
+
+    .weeks-cell {
+      cursor: pointer;
+      transition: fill 200ms ease;
+    }
+
+    .weeks-cell:hover {
+      filter: brightness(1.08);
+    }
+
+    .weeks-cell-group {
+      cursor: pointer;
+    }
+
+    .weeks-cell-group .weeks-cell-half {
+      transition: fill 200ms ease;
+    }
+
+    .weeks-cell-group:hover .weeks-cell-half {
+      filter: brightness(1.08);
+    }
+
+    .weeks-highlight {
+      pointer-events: none;
+      transition: opacity 100ms ease;
+    }
+
+    .weeks-tooltip {
+      position: fixed;
+      z-index: 1001;
+      max-width: 280px;
+      padding: 12px 14px;
+      border: 1px solid rgba(122, 92, 62, 0.18);
+      border-radius: 14px;
+      background:
+        linear-gradient(180deg, rgba(255,255,255,0.96), rgba(246, 238, 228, 0.96)),
+        var(--surface-strong);
+      box-shadow: 0 24px 48px rgba(44, 38, 32, 0.18);
+      backdrop-filter: blur(16px);
+      color: var(--text);
+      opacity: 0;
+      transform: translateY(8px) scale(.98);
+      transform-origin: top center;
+      transition: opacity .16s ease, transform .16s ease;
+      pointer-events: none;
+      font-size: .78rem;
+      line-height: 1.5;
+    }
+
+    .weeks-tooltip.is-visible {
+      opacity: 1;
+      transform: translateY(0) scale(1);
+    }
+
+    .weeks-tooltip-week {
+      font-weight: 600;
+      margin-bottom: 6px;
+      font-size: .72rem;
+      color: var(--muted);
+      text-transform: uppercase;
+      letter-spacing: .03em;
+    }
+
+    .weeks-tooltip-book + .weeks-tooltip-book {
+      margin-top: 8px;
+      padding-top: 8px;
+      border-top: 1px solid var(--border);
+    }
+
+    .weeks-tooltip-title {
+      font-family: 'Cormorant Garamond', 'Times New Roman', serif;
+      font-size: 1.05rem;
+      font-weight: 600;
+      line-height: 1.15;
+    }
+
+    .weeks-tooltip-author {
+      font-size: .74rem;
+      color: var(--muted);
+    }
+
+    .weeks-tooltip-tags {
+      font-size: .68rem;
+      color: var(--muted);
+      margin-top: 2px;
+    }
+
+    .weeks-missing-note {
+      font-size: .72rem;
+      color: var(--muted);
+      margin-top: 8px;
+    }
+
+    .weeks-subtitle {
+      font-size: .88rem;
+      color: var(--muted);
+      margin-bottom: 16px;
+    }
+
+    @media (max-width: 768px) {
+      .weeks-legend { font-size: .65rem; gap: 8px; }
+      .weeks-tooltip { max-width: 240px; font-size: .74rem; }
+    }
   </style>
 </head>
 <body>
@@ -1058,14 +1222,35 @@
       <p class="site-subtitle">What I’ve been reading, what’s still open, and the patterns that start to appear when the shelf gets large enough.</p>
     </div>
     <nav>
+      <a href="#reading-weeks">Life in weeks</a>
       <a href="#taste-profile">Taste profile</a>
       <a href="#read">Books read</a>
       <a href="#currently-reading">Reading</a>
       <a href="#to-read">Want to read</a>
-      <a href="#recommendations">AI Picks</a>
+      <a href="#recommendations">AI picks</a>
     </nav>
   </div>
 </header>
+
+<section id="reading-weeks" class="section hidden">
+  <div class="container">
+    <div class="section-header">
+      <div>
+        <h2 class="section-heading">Reading Life</h2>
+      </div>
+    </div>
+    <p class="weeks-subtitle" id="weeks-subtitle"></p>
+    <div class="weeks-controls">
+      <div class="weeks-mode-toggle" id="weeks-mode-toggle">
+        <button class="pill active" data-mode="geography">Geography</button>
+        <button class="pill" data-mode="genre">Genre</button>
+      </div>
+      <div class="weeks-legend" id="weeks-legend"></div>
+    </div>
+    <div class="weeks-grid-wrap" id="weeks-grid-wrap"></div>
+    <p class="weeks-missing-note hidden" id="weeks-missing-note"></p>
+  </div>
+</section>
 
 <section id="taste-profile" class="section hidden">
   <div class="container taste-profile">
@@ -1200,6 +1385,7 @@
 </footer>
 
 <div class="book-hovercard" id="book-hovercard" hidden aria-hidden="true"></div>
+<div class="weeks-tooltip" id="weeks-tooltip" aria-hidden="true"></div>
 
 <script>
 const state = { sort: 'date_read', rating: 0, shelves: [], query: '' };
@@ -1722,6 +1908,7 @@ async function load() {
   buildShelfTags(allReadBooks);
   applyHash();
   renderReadGrid();
+  renderReadingWeeks(allReadBooks);
   renderCurrentlyReading(books.currently_reading || []);
   renderToRead(books.to_read || []);
 
@@ -1881,6 +2068,499 @@ document.getElementById('regenerate-btn').addEventListener('click', async () => 
     btn.disabled = false;
   }
 });
+
+// ── Reading Life in Weeks ──
+
+const GEO_COLORS = {
+  russia: '#5E8E5E', china: '#CC6B45', france: '#BFA042', germany: '#807E8E',
+  italy: '#C4885A', other: '#5A9E9A', britain: '#A8586A', america: '#6B8CAE',
+  untagged: '#CDC4B5'
+};
+const GEO_LABELS = {
+  russia: 'Russia', china: 'Chinese', france: 'France', germany: 'Germany',
+  italy: 'Italy', other: 'Other', britain: 'Britain', america: 'America',
+  untagged: 'Untagged'
+};
+const GEO_PRIORITY = [
+  { key: 'russia', tags: ['россия'] },
+  { key: 'china', tags: ['中文书', 'china'] },
+  { key: 'france', tags: ['france'] },
+  { key: 'germany', tags: ['germany'] },
+  { key: 'italy', tags: ['italy'] },
+];
+const GEO_OTHER_TAGS = new Set([
+  'india', 'argentina', 'ireland', 'japan', 'turkey', 'belarus', 'on-africa',
+  'korea', 'spain', 'brazil', 'mexico', 'poland', 'czech', 'colombia',
+  'nigeria', 'egypt', 'israel', 'norway', 'sweden', 'denmark', 'iceland',
+  'portugal', 'greece', 'romania', 'hungary', 'austria', 'switzerland',
+  'chile', 'peru', 'south-africa', 'australia', 'new-zealand', 'canada',
+]);
+const GEO_SPECIFIC = new Set([
+  'россия', '中文书', 'china', 'france', 'germany', 'italy', 'britain', 'america',
+  ...GEO_OTHER_TAGS
+]);
+
+const GENRE_COLORS = {
+  fiction: '#C8943E', history: '#5B7FA5', philosophy: '#8B7498',
+  memoir: '#6E9E70', essays: '#5E8B8A', tech: '#B07070',
+  untagged: '#B5AD9E'
+};
+const GENRE_LABELS = {
+  fiction: 'Fiction', history: 'History / Politics', philosophy: 'Philosophy / Mind',
+  memoir: 'Biography / Memoir', essays: 'Essays', tech: 'Technology',
+  untagged: 'Untagged'
+};
+const GENRE_PRIORITY = [
+  { key: 'fiction', tags: ['scifi', 'historical-fiction', 'fantasy', 'fiction'] },
+  { key: 'essays', tags: ['essays'] },
+  { key: 'memoir', tags: ['biography-memoir'] },
+  { key: 'history', tags: ['history', 'politics-and-political-science', 'geopolitics'] },
+  { key: 'philosophy', tags: ['philosophy', 'psychology-psychiatry-psychotherapy', 'religion'] },
+  { key: 'tech', tags: ['technology', 'startup'] },
+];
+
+const RATING_SAT = { 5: 1.0, 4: 0.85, 3: 0.70, 2: 0.50, 1: 0.35, 0: 0.60 };
+const EMPTY_COLOR = '#F5F3F0';
+
+function hexToHsl(hex) {
+  let r = parseInt(hex.slice(1, 3), 16) / 255;
+  let g = parseInt(hex.slice(3, 5), 16) / 255;
+  let b = parseInt(hex.slice(5, 7), 16) / 255;
+  const max = Math.max(r, g, b), min = Math.min(r, g, b);
+  let h, s, l = (max + min) / 2;
+  if (max === min) { h = s = 0; }
+  else {
+    const d = max - min;
+    s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
+    if (max === r) h = ((g - b) / d + (g < b ? 6 : 0)) / 6;
+    else if (max === g) h = ((b - r) / d + 2) / 6;
+    else h = ((r - g) / d + 4) / 6;
+  }
+  return [h * 360, s * 100, l * 100];
+}
+
+function hslToHex(h, s, l) {
+  s /= 100; l /= 100;
+  const a = s * Math.min(l, 1 - l);
+  const f = n => { const k = (n + h / 30) % 12; return l - a * Math.max(-1, Math.min(k - 3, 9 - k, 1)); };
+  const toHex = x => Math.round(x * 255).toString(16).padStart(2, '0');
+  return `#${toHex(f(0))}${toHex(f(8))}${toHex(f(4))}`;
+}
+
+function applySaturation(hex, rating, shelves) {
+  const [h, s, l] = hexToHsl(hex);
+  const isFav = shelves && (shelves.includes('favorite') || shelves.includes('re-readable'));
+  const factor = isFav ? 1.0 : (RATING_SAT[rating] ?? RATING_SAT[0]);
+  return hslToHex(h, s * factor, l);
+}
+
+function classifyGeo(shelves) {
+  if (!shelves || !shelves.length) return 'untagged';
+  const set = new Set(shelves);
+  for (const { key, tags } of GEO_PRIORITY) {
+    for (const t of tags) { if (set.has(t)) return key; }
+  }
+  for (const t of shelves) { if (GEO_OTHER_TAGS.has(t)) return 'other'; }
+  if (set.has('britain')) return 'britain';
+  if (set.has('america')) return 'america';
+  return 'untagged';
+}
+
+function classifyGenre(shelves) {
+  if (!shelves || !shelves.length) return 'untagged';
+  const set = new Set(shelves);
+  for (const { key, tags } of GENRE_PRIORITY) {
+    for (const t of tags) { if (set.has(t)) return key; }
+  }
+  return 'untagged';
+}
+
+function classifyBook(book, mode) {
+  return mode === 'geography' ? classifyGeo(book.shelves) : classifyGenre(book.shelves);
+}
+
+function getBookColor(book, mode) {
+  const colors = mode === 'geography' ? GEO_COLORS : GENRE_COLORS;
+  const cat = classifyBook(book, mode);
+  return applySaturation(colors[cat], book.my_rating || 0, book.shelves);
+}
+
+function getMondayOfWeek(date) {
+  const d = new Date(date);
+  const day = d.getDay();
+  const diff = day === 0 ? -6 : 1 - day;
+  d.setDate(d.getDate() + diff);
+  d.setHours(0, 0, 0, 0);
+  return d;
+}
+
+function weekKey(date) {
+  const mon = getMondayOfWeek(date);
+  const y = mon.getFullYear();
+  const m = String(mon.getMonth() + 1).padStart(2, '0');
+  const d = String(mon.getDate()).padStart(2, '0');
+  return `${y}-${m}-${d}`;
+}
+
+function formatWeekRange(wk) {
+  const mon = new Date(wk + 'T00:00:00');
+  const sun = new Date(mon);
+  sun.setDate(sun.getDate() + 6);
+  const opts = { month: 'short', day: 'numeric' };
+  const monStr = mon.toLocaleDateString('en-US', opts);
+  const sunStr = sun.toLocaleDateString('en-US', { ...opts, year: 'numeric' });
+  return `${monStr} – ${sunStr}`;
+}
+
+function buildWeeksData(books) {
+  const withDate = [];
+  let missingCount = 0;
+  for (const b of books) {
+    if (b.date_read) {
+      withDate.push(b);
+    } else {
+      missingCount++;
+    }
+  }
+  if (!withDate.length) return { rows: [], missingCount, weekMap: new Map() };
+
+  const dates = withDate.map(b => new Date(b.date_read + 'T00:00:00'));
+  const earliest = new Date(Math.min(...dates));
+  const startMon = getMondayOfWeek(earliest);
+  const now = new Date();
+  const endMon = getMondayOfWeek(now);
+
+  const weekMap = new Map();
+  for (const b of withDate) {
+    const wk = weekKey(new Date(b.date_read + 'T00:00:00'));
+    if (!weekMap.has(wk)) weekMap.set(wk, []);
+    weekMap.get(wk).push(b);
+  }
+
+  const rows = [];
+  let currentMon = new Date(startMon);
+  let currentYear = currentMon.getFullYear();
+  let currentRow = { year: currentYear, weeks: [], bookCount: 0 };
+
+  while (currentMon <= endMon) {
+    const yr = currentMon.getFullYear();
+    if (yr !== currentYear) {
+      rows.push(currentRow);
+      currentYear = yr;
+      currentRow = { year: yr, weeks: [], bookCount: 0 };
+    }
+    const wk = weekKey(currentMon);
+    const bks = weekMap.get(wk) || [];
+    currentRow.weeks.push({ key: wk, books: bks });
+    currentRow.bookCount += bks.length;
+    currentMon.setDate(currentMon.getDate() + 7);
+  }
+  if (currentRow.weeks.length) rows.push(currentRow);
+
+  const filteredRows = rows.filter(r => r.bookCount > 0);
+  return { rows: filteredRows, missingCount, weekMap };
+}
+
+let weeksMode = 'geography';
+let weeksData = null;
+let weeksWeekMap = null;
+let weeksTooltipTimer = null;
+const weeksTooltipEl = document.getElementById('weeks-tooltip');
+
+function renderWeeksLegend(mode) {
+  const colors = mode === 'geography' ? GEO_COLORS : GENRE_COLORS;
+  const labels = mode === 'geography' ? GEO_LABELS : GENRE_LABELS;
+  const el = document.getElementById('weeks-legend');
+  el.innerHTML = Object.keys(colors).map(k =>
+    `<span class="weeks-legend-item"><span class="weeks-legend-swatch" style="background:${colors[k]}"></span>${labels[k]}</span>`
+  ).join('');
+}
+
+function renderWeeksSvg(data, mode) {
+  const { rows } = data;
+  if (!rows.length) return;
+
+  const cellSize = 14;
+  const gap = 2;
+  const step = cellSize + gap;
+  const labelW = 76;
+  const monthH = 16;
+  const maxCols = Math.max(...rows.map(r => r.weeks.length), 53);
+  const gridW = labelW + maxCols * step;
+  const gridH = monthH + rows.length * step;
+
+  const ns = 'http://www.w3.org/2000/svg';
+  const svg = document.createElementNS(ns, 'svg');
+  svg.setAttribute('viewBox', `0 0 ${gridW} ${gridH}`);
+  svg.setAttribute('width', '100%');
+  svg.setAttribute('role', 'img');
+  svg.setAttribute('aria-label', 'Reading life in weeks grid');
+
+  // month markers
+  const months = ['J','F','M','A','M','J','J','A','S','O','N','D'];
+  const monthWeeks = [0, 4, 9, 13, 17, 22, 26, 31, 35, 39, 44, 48];
+  for (let i = 0; i < 12; i++) {
+    const t = document.createElementNS(ns, 'text');
+    t.setAttribute('x', labelW + monthWeeks[i] * step + cellSize / 2);
+    t.setAttribute('y', monthH - 4);
+    t.setAttribute('text-anchor', 'middle');
+    t.setAttribute('font-size', '8');
+    t.setAttribute('fill', '#7c7267');
+    t.setAttribute('font-family', 'Inter, system-ui, sans-serif');
+    t.textContent = months[i];
+    svg.appendChild(t);
+  }
+
+  // highlight rect (reused on hover)
+  const highlight = document.createElementNS(ns, 'rect');
+  highlight.classList.add('weeks-highlight');
+  highlight.setAttribute('rx', '2');
+  highlight.setAttribute('stroke', 'rgba(38,31,24,0.5)');
+  highlight.setAttribute('stroke-width', '1.5');
+  highlight.setAttribute('fill', 'none');
+  highlight.setAttribute('opacity', '0');
+  highlight.setAttribute('width', cellSize + 2);
+  highlight.setAttribute('height', cellSize + 2);
+
+  for (let ri = 0; ri < rows.length; ri++) {
+    const row = rows[ri];
+    const y = monthH + ri * step;
+
+    // year label
+    const label = document.createElementNS(ns, 'text');
+    label.setAttribute('x', labelW - 8);
+    label.setAttribute('y', y + cellSize * 0.78);
+    label.setAttribute('text-anchor', 'end');
+    label.setAttribute('font-size', '8');
+    label.setAttribute('fill', '#7c7267');
+    label.setAttribute('font-family', 'Inter, system-ui, sans-serif');
+    label.textContent = `${row.year} (${row.bookCount})`;
+    svg.appendChild(label);
+
+    for (let ci = 0; ci < row.weeks.length; ci++) {
+      const wk = row.weeks[ci];
+      const x = labelW + ci * step;
+      const bks = wk.books;
+
+      if (bks.length === 2) {
+        // diagonal split
+        const g = document.createElementNS(ns, 'g');
+        g.classList.add('weeks-cell-group');
+        g.dataset.week = wk.key;
+
+        const sorted = [...bks].sort((a, b) => (b.my_rating || 0) - (a.my_rating || 0));
+        const c1 = getBookColor(sorted[0], mode);
+        const c2 = getBookColor(sorted[1], mode);
+
+        const p1 = document.createElementNS(ns, 'polygon');
+        p1.setAttribute('points', `${x},${y} ${x + cellSize},${y} ${x},${y + cellSize}`);
+        p1.setAttribute('fill', c1);
+        p1.classList.add('weeks-cell-half');
+        p1.dataset.mode_geo = getBookColor(sorted[0], 'geography');
+        p1.dataset.mode_genre = getBookColor(sorted[0], 'genre');
+
+        const p2 = document.createElementNS(ns, 'polygon');
+        p2.setAttribute('points', `${x + cellSize},${y} ${x + cellSize},${y + cellSize} ${x},${y + cellSize}`);
+        p2.setAttribute('fill', c2);
+        p2.classList.add('weeks-cell-half');
+        p2.dataset.mode_geo = getBookColor(sorted[1], 'geography');
+        p2.dataset.mode_genre = getBookColor(sorted[1], 'genre');
+
+        g.appendChild(p1);
+        g.appendChild(p2);
+        svg.appendChild(g);
+      } else {
+        const rect = document.createElementNS(ns, 'rect');
+        rect.setAttribute('x', x);
+        rect.setAttribute('y', y);
+        rect.setAttribute('width', cellSize);
+        rect.setAttribute('height', cellSize);
+        rect.setAttribute('rx', '2');
+        rect.classList.add('weeks-cell');
+        rect.dataset.week = wk.key;
+
+        if (bks.length === 0) {
+          rect.setAttribute('fill', EMPTY_COLOR);
+        } else if (bks.length === 1) {
+          const c = getBookColor(bks[0], mode);
+          rect.setAttribute('fill', c);
+          rect.dataset.mode_geo = getBookColor(bks[0], 'geography');
+          rect.dataset.mode_genre = getBookColor(bks[0], 'genre');
+        } else {
+          // 3+ books: highest rated
+          const best = [...bks].sort((a, b) => (b.my_rating || 0) - (a.my_rating || 0))[0];
+          const c = getBookColor(best, mode);
+          rect.setAttribute('fill', c);
+          rect.dataset.mode_geo = getBookColor(best, 'geography');
+          rect.dataset.mode_genre = getBookColor(best, 'genre');
+        }
+        svg.appendChild(rect);
+      }
+    }
+  }
+
+  svg.appendChild(highlight);
+
+  const wrap = document.getElementById('weeks-grid-wrap');
+  wrap.innerHTML = '';
+  wrap.appendChild(svg);
+
+  // Store highlight ref
+  wrap._highlight = highlight;
+}
+
+function updateWeeksColors(mode) {
+  const wrap = document.getElementById('weeks-grid-wrap');
+  const svg = wrap.querySelector('svg');
+  if (!svg) return;
+
+  const attr = mode === 'geography' ? 'mode_geo' : 'mode_genre';
+
+  svg.querySelectorAll('.weeks-cell').forEach(el => {
+    if (el.dataset[attr]) el.setAttribute('fill', el.dataset[attr]);
+  });
+  svg.querySelectorAll('.weeks-cell-half').forEach(el => {
+    if (el.dataset[attr]) el.setAttribute('fill', el.dataset[attr]);
+  });
+}
+
+function showWeeksTooltip(target, wkKey) {
+  const books = weeksWeekMap.get(wkKey);
+  if (!books || !books.length) return;
+
+  let html = `<div class="weeks-tooltip-week">${formatWeekRange(wkKey)}</div>`;
+  for (const b of books) {
+    const starStr = b.my_rating ? '★'.repeat(b.my_rating) + '<span style="color:var(--star-off)">' + '★'.repeat(5 - b.my_rating) + '</span>' : '';
+    const tags = (b.shelves || []).filter(t => !['read', 'currently-reading', 'to-read'].includes(t)).join(', ');
+    html += `<div class="weeks-tooltip-book">
+      <div class="weeks-tooltip-title">${escHtml(b.title)}</div>
+      <div class="weeks-tooltip-author">${escHtml(b.author)}${starStr ? ' · ' + starStr : ''}</div>
+      ${tags ? `<div class="weeks-tooltip-tags">${escHtml(tags)}</div>` : ''}
+    </div>`;
+  }
+  weeksTooltipEl.innerHTML = html;
+  weeksTooltipEl.hidden = false;
+  weeksTooltipEl.setAttribute('aria-hidden', 'false');
+  weeksTooltipEl.classList.remove('is-visible');
+
+  requestAnimationFrame(() => {
+    const rect = target.getBoundingClientRect();
+    const ttRect = weeksTooltipEl.getBoundingClientRect();
+    const gap = 10;
+    let top = rect.top - ttRect.height - gap;
+    if (top < 8) top = rect.bottom + gap;
+    let left = rect.left + (rect.width - ttRect.width) / 2;
+    left = Math.max(8, Math.min(left, window.innerWidth - ttRect.width - 8));
+    weeksTooltipEl.style.top = `${Math.round(top)}px`;
+    weeksTooltipEl.style.left = `${Math.round(left)}px`;
+    weeksTooltipEl.classList.add('is-visible');
+  });
+}
+
+function hideWeeksTooltip() {
+  weeksTooltipEl.classList.remove('is-visible');
+  weeksTooltipEl.setAttribute('aria-hidden', 'true');
+  setTimeout(() => {
+    if (!weeksTooltipEl.classList.contains('is-visible')) weeksTooltipEl.hidden = true;
+  }, 160);
+}
+
+function setupWeeksEvents() {
+  const wrap = document.getElementById('weeks-grid-wrap');
+  const highlight = wrap._highlight;
+  let hoverTimer = null;
+
+  wrap.addEventListener('mouseover', e => {
+    const cell = e.target.closest('.weeks-cell, .weeks-cell-group');
+    if (!cell) return;
+    clearTimeout(hoverTimer);
+    hoverTimer = setTimeout(() => {
+      const wk = cell.dataset.week;
+      if (wk && weeksWeekMap.has(wk)) {
+        showWeeksTooltip(cell, wk);
+      }
+    }, 200);
+
+    // highlight
+    if (highlight) {
+      const cellSize = 14;
+      const r = cell.getBoundingClientRect();
+      const svgRect = wrap.querySelector('svg').getBoundingClientRect();
+      const svgEl = wrap.querySelector('svg');
+      const vb = svgEl.viewBox.baseVal;
+      const scaleX = vb.width / svgRect.width;
+      const scaleY = vb.height / svgRect.height;
+      const cx = (r.left - svgRect.left) * scaleX;
+      const cy = (r.top - svgRect.top) * scaleY;
+      highlight.setAttribute('x', cx - 1);
+      highlight.setAttribute('y', cy - 1);
+      highlight.setAttribute('opacity', '1');
+    }
+  });
+
+  wrap.addEventListener('mouseout', e => {
+    const cell = e.target.closest('.weeks-cell, .weeks-cell-group');
+    if (!cell) return;
+    clearTimeout(hoverTimer);
+    hideWeeksTooltip();
+    if (highlight) highlight.setAttribute('opacity', '0');
+  });
+
+  // mobile tap
+  wrap.addEventListener('click', e => {
+    if (window.matchMedia('(hover: hover)').matches) return;
+    const cell = e.target.closest('.weeks-cell, .weeks-cell-group');
+    if (!cell) { hideWeeksTooltip(); return; }
+    const wk = cell.dataset.week;
+    if (wk && weeksWeekMap.has(wk)) {
+      showWeeksTooltip(cell, wk);
+    }
+  });
+
+  // toggle
+  document.getElementById('weeks-mode-toggle').addEventListener('click', e => {
+    const btn = e.target.closest('.pill');
+    if (!btn || btn.classList.contains('active')) return;
+    document.querySelectorAll('#weeks-mode-toggle .pill').forEach(p => p.classList.remove('active'));
+    btn.classList.add('active');
+    weeksMode = btn.dataset.mode;
+    updateWeeksColors(weeksMode);
+    renderWeeksLegend(weeksMode);
+  });
+
+  // dismiss tooltip on click outside (mobile)
+  document.addEventListener('click', e => {
+    if (!e.target.closest('.weeks-cell, .weeks-cell-group, .weeks-tooltip')) {
+      hideWeeksTooltip();
+    }
+  });
+}
+
+function renderReadingWeeks(books) {
+  const readBooks = books.filter(b => b.exclusive_shelf === 'read' || !b.exclusive_shelf);
+  const data = buildWeeksData(readBooks);
+  weeksData = data;
+  weeksWeekMap = data.weekMap;
+
+  if (!data.rows.length) return;
+
+  const section = document.getElementById('reading-weeks');
+  section.classList.remove('hidden');
+
+  const firstYear = data.rows[0].year;
+  document.getElementById('weeks-subtitle').textContent =
+    `Every week since ${firstYear}. Colored weeks mark a finished book.`;
+
+  renderWeeksSvg(data, weeksMode);
+  renderWeeksLegend(weeksMode);
+  setupWeeksEvents();
+
+  if (data.missingCount > 0) {
+    const note = document.getElementById('weeks-missing-note');
+    note.textContent = `${data.missingCount} book${data.missingCount > 1 ? 's' : ''} without a recorded finish date ${data.missingCount > 1 ? 'are' : 'is'} not shown in this view.`;
+    note.classList.remove('hidden');
+  }
+}
 
 // ── Update footer ──
 function updateFooter(generated_at) {


### PR DESCRIPTION
SVG-based heat map where every week from the reader's first finished book to today gets a cell, colored by geography or genre of books completed that week. Rating modulates saturation. Two-book weeks show diagonal splits; tooltips show book details on hover/tap. Responsive via SVG viewBox scaling. Skips years with zero books.

Closes #10