### PR TITLE
Add notes table migration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,8 @@ FORCE_LLM ?= 0
 
 .PHONY: install parse llm llm-force llm-staging llm-staging-force build refresh-data dev \
         deploy deploy-sync restart-api backup pull-db push-db \
-        deploy-staging deploy-staging-sync restart-staging-api seed-staging
+        deploy-staging deploy-staging-sync restart-staging-api seed-staging \
+        add-notes-table
 
 install:
 	$(PYTHON) -m venv $(VENV_DIR)
@@ -136,3 +137,8 @@ seed-staging:
 	ssh $(VPS_HOST) 'cp $(VPS_PATH)/data/bookshelf.db $(STAGING_VPS_PATH)/data/bookshelf.db'
 	@echo "Done. Restart staging to pick up the new database:"
 	@echo "  make restart-staging-api"
+
+# ── Migrations ──────────────────────────────────────────────────────────────
+
+add-notes-table:
+	$(RUN_PYTHON) scripts/add_notes_table.py

--- a/scripts/add_notes_table.py
+++ b/scripts/add_notes_table.py
@@ -1,0 +1,60 @@
+"""
+Migration script: add the `notes` table to the bookshelf database.
+
+Idempotent — safe to run multiple times.
+"""
+
+import os
+import sqlite3
+import sys
+from pathlib import Path
+
+DB_PATH = os.environ.get("DB_PATH", "data/bookshelf.db")
+
+SCHEMA = """
+CREATE TABLE IF NOT EXISTS notes (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    source_type TEXT NOT NULL DEFAULT 'book'
+        CHECK (source_type IN ('book', 'article', 'movie', 'blog', 'report', 'other')),
+    source_id INTEGER NOT NULL,
+    note_type TEXT NOT NULL DEFAULT 'thought'
+        CHECK (note_type IN ('thought', 'quote', 'connection', 'disagreement', 'question')),
+    content TEXT NOT NULL,
+    page_or_location TEXT,
+    connected_source_type TEXT,
+    connected_source_id INTEGER,
+    tags TEXT,
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+    updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_notes_source ON notes(source_type, source_id);
+CREATE INDEX IF NOT EXISTS idx_notes_type ON notes(note_type);
+CREATE INDEX IF NOT EXISTS idx_notes_connected ON notes(connected_source_type, connected_source_id);
+"""
+
+
+def main() -> None:
+    db_path = Path(DB_PATH)
+    if not db_path.exists():
+        print(f"Error: database not found at {db_path}", file=sys.stderr)
+        sys.exit(1)
+
+    conn = sqlite3.connect(str(db_path))
+    try:
+        # Check if table already exists
+        row = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='notes'"
+        ).fetchone()
+
+        if row:
+            print("Notes table already exists.")
+        else:
+            conn.executescript(SCHEMA)
+            print("Notes table created.")
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Adds `scripts/add_notes_table.py` — idempotent migration script that creates the `notes` table with columns for source linking, note types, tags, and connections between books
- Adds `make add-notes-table` Makefile target
- Task 1 of #5

## Test plan
- [x] Run `make add-notes-table` — prints "Notes table created."
- [x] `sqlite3 data/bookshelf.db ".tables"` — `notes` appears
- [x] `sqlite3 data/bookshelf.db ".schema notes"` — schema matches spec (columns, CHECK constraints, 3 indexes)
- [x] Run `make add-notes-table` again — prints "Notes table already exists." with no error

🤖 Generated with [Claude Code](https://claude.com/claude-code)