### PR TITLE
Polish: note counts, click-to-navigate, edit page link

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -150,6 +150,19 @@ async def get_books() -> dict:
             raise HTTPException(status_code=503, detail="No books found in database.")
         if not BOOKS_DATA_FILE.exists():
             raise HTTPException(status_code=503, detail="books.json not found. Run `make parse` first.")
+
+    # Enrich with note_count per book
+    if USE_SQLITE:
+        rows = store.conn().execute(
+            "SELECT source_id, COUNT(*) as cnt FROM notes "
+            "WHERE source_type = 'book' GROUP BY source_id"
+        ).fetchall()
+        counts = {row["source_id"]: row["cnt"] for row in rows}
+        for shelf in books_payload.get("books", {}).values():
+            if isinstance(shelf, list):
+                for book in shelf:
+                    book["note_count"] = counts.get(book.get("id", 0), 0)
+
     return books_payload
 
 

--- a/site/book.html
+++ b/site/book.html
@@ -366,7 +366,7 @@ function renderNoteHtml(note) {
     const coverImg = cb.cover_url
       ? `<img src="${escHtml(cb.cover_url)}" alt="${escHtml(cb.title)}">` : '';
     connectedHtml = `
-      <a class="connected-card" href="/book?id=${cb.id}">
+      <a class="connected-card" href="book.html?id=${cb.id}">
         <div class="connected-cover">${coverImg}</div>
         <div>
           <div class="connected-title">${escHtml(cb.title)}</div>

--- a/site/edit.html
+++ b/site/edit.html
@@ -91,6 +91,7 @@
 <body>
 <div class="container">
   <a class="back" href="index.html">&larr; Back to bookshelf</a>
+  <a class="back" id="book-page-link" style="display:none;margin-left:12px">&rarr; View this book's page (with notes)</a>
   <h1>Edit Book</h1>
 
   <div class="loading" id="loading">Loading book…</div>
@@ -340,6 +341,9 @@ async function loadBook() {
     populateForm(book);
     document.getElementById('loading').classList.add('hidden');
     document.getElementById('edit-form').classList.remove('hidden');
+    const bookPageLink = document.getElementById('book-page-link');
+    bookPageLink.href = `book.html?id=${bookId}`;
+    bookPageLink.style.display = '';
   } catch (err) {
     document.getElementById('loading').textContent = `Failed to load: ${err.message}`;
   }

--- a/site/index.html
+++ b/site/index.html
@@ -1494,6 +1494,7 @@ function buildCardDataAttrs(book, context) {
     'data-shelves': (book.shelves || []).slice(0, 6).join('|'),
     'data-review': (book.my_review || '').trim(),
     'data-notes': (book.notes || '').trim(),
+    'data-note-count': book.note_count || '',
     'data-cover-url': book.cover_url || '',
   };
 
@@ -1548,7 +1549,7 @@ function buildHovercardContent(card) {
     ${shelvesHtml}
     ${reviewHtml}
     ${notesHtml}
-    ${card.dataset.id ? `<a href="/book?id=${escHtml(card.dataset.id)}" class="hovercard-link" onclick="event.stopPropagation()">&rarr; View full page &amp; notes</a>` : ''}
+    ${card.dataset.id ? `<a href="book.html?id=${escHtml(card.dataset.id)}" class="hovercard-link" onclick="event.stopPropagation()">&rarr; View full page &amp; ${card.dataset.noteCount ? card.dataset.noteCount + ' notes' : 'notes'}</a>` : ''}
   `;
 }
 
@@ -1626,9 +1627,18 @@ document.addEventListener('focusout', e => {
 });
 
 document.addEventListener('click', e => {
+  // Ignore clicks on edit icons and other links inside cards
+  if (e.target.closest('.edit-icon')) return;
+
   const card = e.target.closest('.book-card');
   if (!card) {
     hideHovercard();
+    return;
+  }
+
+  // Click navigates to book detail page
+  if (card.dataset.id) {
+    window.location.href = `book.html?id=${card.dataset.id}`;
     return;
   }
 


### PR DESCRIPTION
## Summary
- Add `note_count` to each book in `/api/books` response (single GROUP BY query)
- Clicking a book card on `index.html` navigates to the book detail page
- Hovercard shows "View full page & 5 notes" when book has notes
- `edit.html` shows "View this book's page (with notes)" link
- Fix all internal links to use `book.html?id=` for static file serving
- Part of #5

## Test plan
- [x] On `index.html`, hover a book with notes — shows "View full page & 5 notes"
- [x] On `index.html`, hover a book without notes — shows "View full page & notes"
- [x] Click a book card — navigates to `book.html?id={id}`
- [x] On `edit.html`, "View this book's page (with notes)" link works
- [x] Connected book cards on book page link correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)