### PR TITLE
[codex] Add activity log feed and public log page

### DIFF
--- a/api/activity.py
+++ b/api/activity.py
@@ -1,0 +1,91 @@
+"""Public activity-feed endpoints for the bookshelf API."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, Query
+
+from db import list_activity_rows
+
+router = APIRouter(prefix="/api/activity")
+
+
+def _get_deps() -> tuple:
+    """Return (store, USE_SQLITE) from app state."""
+    from api.main import USE_SQLITE, store
+
+    return store, USE_SQLITE
+
+
+def _book_href(book_id: int, book_exists: bool) -> str | None:
+    return f"book.html?id={book_id}" if book_exists else None
+
+
+def _summary_for_row(row: dict[str, Any]) -> str:
+    title = row.get("book_title") or "Untitled"
+    event_type = row.get("event_type")
+
+    if event_type == "book_added_to_to_read":
+        return f"Added {title} to to-read"
+    if event_type == "started_reading":
+        return f"Started {title}"
+    if event_type == "finished_reading":
+        return f"Finished {title}"
+    if event_type == "note_added" and row.get("note_type") == "quote":
+        return f"Added a quote from {title}"
+    return f"Added a note on {title}"
+
+
+def _serialize_row(row: dict[str, Any]) -> dict[str, Any]:
+    payload = {
+        "id": row["id"],
+        "event_type": row["event_type"],
+        "created_at": row["created_at"],
+        "summary": _summary_for_row(row),
+        "book": {
+            "id": row["book_id"],
+            "title": row["book_title"],
+            "author": row["book_author"],
+            "href": _book_href(row["book_id"], bool(row["book_exists"])),
+        },
+    }
+    if row.get("note_type"):
+        payload["note_type"] = row["note_type"]
+    return payload
+
+
+def _empty_response(limit: int, offset: int) -> dict[str, Any]:
+    return {
+        "items": [],
+        "pagination": {
+            "limit": limit,
+            "offset": offset,
+            "has_more": False,
+            "next_offset": None,
+        },
+    }
+
+
+@router.get("")
+async def get_activity(
+    limit: int = Query(default=30, ge=1, le=100),
+    offset: int = Query(default=0, ge=0),
+) -> dict[str, Any]:
+    store, USE_SQLITE = _get_deps()
+    if not USE_SQLITE:
+        return _empty_response(limit, offset)
+
+    rows = list_activity_rows(store.conn(), limit=limit + 1, offset=offset)
+    has_more = len(rows) > limit
+    visible_rows = rows[:limit]
+
+    return {
+        "items": [_serialize_row(row) for row in visible_rows],
+        "pagination": {
+            "limit": limit,
+            "offset": offset,
+            "has_more": has_more,
+            "next_offset": offset + limit if has_more else None,
+        },
+    }

--- a/api/main.py
+++ b/api/main.py
@@ -17,6 +17,7 @@ from bookshelf_data import (
     load_env_file,
     utc_now_iso,
 )
+from api.activity import router as activity_router
 from api.auth import verify_auth
 from api.notes import router as notes_router
 
@@ -49,6 +50,7 @@ else:
     store = BookshelfStore(BOOKS_DATA_FILE, LLM_CACHE_FILE)
 
 app = FastAPI(title="Bookshelf API")
+app.include_router(activity_router)
 app.include_router(notes_router)
 app.add_middleware(
     CORSMiddleware,
@@ -89,6 +91,39 @@ def _normalize_shelves(value: object) -> list[str]:
         seen.add(key)
         normalized.append(tag)
     return normalized
+
+
+def _created_book_activity_type(shelf: str) -> str | None:
+    return {
+        "to_read": "book_added_to_to_read",
+        "currently_reading": "started_reading",
+        "read": "finished_reading",
+    }.get(shelf)
+
+
+def _transition_book_activity_type(old_shelf: str, new_shelf: str) -> str | None:
+    if old_shelf == new_shelf:
+        return None
+    if new_shelf == "currently_reading":
+        return "started_reading"
+    if new_shelf == "read":
+        return "finished_reading"
+    return None
+
+
+def _log_book_activity(conn, *, event_type: str | None, book: dict) -> None:
+    if not event_type:
+        return
+
+    from db import insert_activity
+
+    insert_activity(
+        conn,
+        event_type=event_type,
+        book_id=book["id"],
+        book_title=book.get("title") or "Untitled",
+        book_author=book.get("author") or "Unknown author",
+    )
 
 
 # ── LLM regeneration state ──────────────────────────────────────────────────
@@ -196,7 +231,7 @@ async def create_book(request: Request) -> dict:
     if not title or not author:
         raise HTTPException(status_code=422, detail="title and author are required.")
 
-    from db import insert_book
+    from db import get_book_by_id, insert_book
 
     shelf = body.get("exclusive_shelf", "to_read")
     shelves = _normalize_shelves(body.get("shelves"))
@@ -218,12 +253,20 @@ async def create_book(request: Request) -> dict:
         "goodreads_id": body.get("goodreads_id") or None,
     }
 
-    book_id = insert_book(store.conn(), book_data)
-    store.conn().commit()
-    _maybe_trigger_llm_regen(shelf)
+    conn = store.conn()
+    try:
+        book_id = insert_book(conn, book_data)
+        book = get_book_by_id(conn, book_id)
+        if book is None:
+            raise HTTPException(status_code=500, detail="Book was created but could not be loaded.")
+        _log_book_activity(conn, event_type=_created_book_activity_type(shelf), book=book)
+        conn.commit()
+    except Exception:
+        conn.rollback()
+        raise
 
-    from db import get_book_by_id
-    return get_book_by_id(store.conn(), book_id)
+    _maybe_trigger_llm_regen(shelf)
+    return book
 
 
 @app.put("/api/books/{book_id}")
@@ -245,15 +288,28 @@ async def update_book_endpoint(book_id: int, request: Request) -> dict:
     if "shelves" in body:
         body["shelves"] = _normalize_shelves(body.get("shelves"))
 
-    if not update_book(store.conn(), book_id, body):
-        raise HTTPException(status_code=404, detail="Book not found.")
+    conn = store.conn()
+    try:
+        if not update_book(conn, book_id, body):
+            raise HTTPException(status_code=404, detail="Book not found.")
+        updated = get_book_by_id(conn, book_id)
+        if updated is None:
+            raise HTTPException(status_code=404, detail="Book not found.")
+        old_shelf = existing.get("exclusive_shelf", "")
+        new_shelf = updated.get("exclusive_shelf", old_shelf)
+        _log_book_activity(
+            conn,
+            event_type=_transition_book_activity_type(old_shelf, new_shelf),
+            book=updated,
+        )
+        conn.commit()
+    except Exception:
+        conn.rollback()
+        raise
 
-    old_shelf = existing.get("exclusive_shelf", "")
-    new_shelf = body.get("exclusive_shelf", old_shelf)
     if old_shelf == "read" or new_shelf == "read":
         _maybe_trigger_llm_regen("read")
-
-    return get_book_by_id(store.conn(), book_id)
+    return updated
 
 
 @app.delete("/api/books/{book_id}")
@@ -269,7 +325,13 @@ async def delete_book_endpoint(book_id: int, request: Request) -> dict:
         raise HTTPException(status_code=404, detail="Book not found.")
 
     shelf = existing.get("exclusive_shelf", "")
-    delete_book(store.conn(), book_id)
+    conn = store.conn()
+    try:
+        delete_book(conn, book_id)
+        conn.commit()
+    except Exception:
+        conn.rollback()
+        raise
     _maybe_trigger_llm_regen(shelf)
 
     return {"deleted": True, "id": book_id}

--- a/api/notes.py
+++ b/api/notes.py
@@ -7,6 +7,8 @@ from typing import Any
 
 from fastapi import APIRouter, HTTPException, Request
 
+from db import insert_activity
+
 router = APIRouter(prefix="/api/books/{book_id}/notes")
 
 VALID_NOTE_TYPES = ("thought", "quote", "connection", "disagreement", "question")
@@ -119,29 +121,45 @@ async def create_note(book_id: int, request: Request) -> dict:
     conn = store.conn()
 
     # Verify book exists
-    book = conn.execute("SELECT id FROM books WHERE id = ?", (book_id,)).fetchone()
+    book = conn.execute(
+        "SELECT id, title, author FROM books WHERE id = ?",
+        (book_id,),
+    ).fetchone()
     if book is None:
         raise HTTPException(status_code=404, detail="Book not found.")
 
     body = await request.json()
     fields = _validate_note_body(body)
 
-    cursor = conn.execute(
-        """INSERT INTO notes (source_type, source_id, note_type, content,
-           page_or_location, connected_source_type, connected_source_id, tags)
-           VALUES ('book', ?, ?, ?, ?, ?, ?, ?)""",
-        (
-            book_id,
-            fields["note_type"],
-            fields["content"],
-            fields["page_or_location"],
-            fields["connected_source_type"],
-            fields["connected_source_id"],
-            fields["tags"],
-        ),
-    )
-    conn.commit()
-    return {"id": cursor.lastrowid, "status": "created"}
+    try:
+        cursor = conn.execute(
+            """INSERT INTO notes (source_type, source_id, note_type, content,
+               page_or_location, connected_source_type, connected_source_id, tags)
+               VALUES ('book', ?, ?, ?, ?, ?, ?, ?)""",
+            (
+                book_id,
+                fields["note_type"],
+                fields["content"],
+                fields["page_or_location"],
+                fields["connected_source_type"],
+                fields["connected_source_id"],
+                fields["tags"],
+            ),
+        )
+        insert_activity(
+            conn,
+            event_type="note_added",
+            book_id=book["id"],
+            note_id=cursor.lastrowid,
+            book_title=book["title"],
+            book_author=book["author"],
+            note_type=fields["note_type"],
+        )
+        conn.commit()
+        return {"id": cursor.lastrowid, "status": "created"}
+    except Exception:
+        conn.rollback()
+        raise
 
 
 @router.put("/{note_id}")
@@ -164,23 +182,27 @@ async def update_note(book_id: int, note_id: int, request: Request) -> dict:
     body = await request.json()
     fields = _validate_note_body(body)
 
-    conn.execute(
-        """UPDATE notes SET note_type = ?, content = ?, page_or_location = ?,
-           connected_source_type = ?, connected_source_id = ?, tags = ?,
-           updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now')
-           WHERE id = ?""",
-        (
-            fields["note_type"],
-            fields["content"],
-            fields["page_or_location"],
-            fields["connected_source_type"],
-            fields["connected_source_id"],
-            fields["tags"],
-            note_id,
-        ),
-    )
-    conn.commit()
-    return {"id": note_id, "status": "updated"}
+    try:
+        conn.execute(
+            """UPDATE notes SET note_type = ?, content = ?, page_or_location = ?,
+               connected_source_type = ?, connected_source_id = ?, tags = ?,
+               updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now')
+               WHERE id = ?""",
+            (
+                fields["note_type"],
+                fields["content"],
+                fields["page_or_location"],
+                fields["connected_source_type"],
+                fields["connected_source_id"],
+                fields["tags"],
+                note_id,
+            ),
+        )
+        conn.commit()
+        return {"id": note_id, "status": "updated"}
+    except Exception:
+        conn.rollback()
+        raise
 
 
 @router.delete("/{note_id}")
@@ -200,6 +222,10 @@ async def delete_note(book_id: int, note_id: int, request: Request) -> dict:
     if existing is None:
         raise HTTPException(status_code=404, detail="Note not found.")
 
-    conn.execute("DELETE FROM notes WHERE id = ?", (note_id,))
-    conn.commit()
-    return {"id": note_id, "status": "deleted"}
+    try:
+        conn.execute("DELETE FROM notes WHERE id = ?", (note_id,))
+        conn.commit()
+        return {"id": note_id, "status": "deleted"}
+    except Exception:
+        conn.rollback()
+        raise

--- a/db.py
+++ b/db.py
@@ -65,10 +65,59 @@ def _migration_v1(conn: sqlite3.Connection) -> None:
     conn.executescript(_SCHEMA_V1)
 
 
+_NOTES_SCHEMA = """
+CREATE TABLE IF NOT EXISTS notes (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    source_type TEXT NOT NULL DEFAULT 'book'
+        CHECK (source_type IN ('book', 'article', 'movie', 'blog', 'report', 'other')),
+    source_id INTEGER NOT NULL,
+    note_type TEXT NOT NULL DEFAULT 'thought'
+        CHECK (note_type IN ('thought', 'quote', 'connection', 'disagreement', 'question')),
+    content TEXT NOT NULL,
+    page_or_location TEXT,
+    connected_source_type TEXT,
+    connected_source_id INTEGER,
+    tags TEXT,
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+    updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_notes_source ON notes(source_type, source_id);
+CREATE INDEX IF NOT EXISTS idx_notes_type ON notes(note_type);
+CREATE INDEX IF NOT EXISTS idx_notes_connected ON notes(connected_source_type, connected_source_id);
+"""
+
+
+_ACTIVITY_LOG_SCHEMA = """
+CREATE TABLE IF NOT EXISTS activity_log (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    event_type TEXT NOT NULL
+        CHECK (event_type IN ('book_added_to_to_read', 'started_reading', 'finished_reading', 'note_added')),
+    book_id INTEGER NOT NULL,
+    note_id INTEGER,
+    book_title TEXT NOT NULL,
+    book_author TEXT NOT NULL,
+    note_type TEXT,
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_activity_log_created_at
+    ON activity_log(created_at DESC, id DESC);
+CREATE INDEX IF NOT EXISTS idx_activity_log_book_id
+    ON activity_log(book_id);
+"""
+
+
+def _migration_v2(conn: sqlite3.Connection) -> None:
+    conn.executescript(_NOTES_SCHEMA)
+    conn.executescript(_ACTIVITY_LOG_SCHEMA)
+
+
 # ── Migration registry ────────────────────────────────────────────────────────
 
 MIGRATIONS: list[tuple[int, Callable[[sqlite3.Connection], None]]] = [
     (1, _migration_v1),
+    (2, _migration_v2),
 ]
 
 
@@ -238,12 +287,55 @@ def update_book(conn: sqlite3.Connection, book_id: int, fields: dict[str, Any]) 
         f"UPDATE books SET {', '.join(set_parts)} WHERE id = ?",
         values,
     )
-    conn.commit()
     return True
 
 
 def delete_book(conn: sqlite3.Connection, book_id: int) -> bool:
     """Delete a book by ID. Returns True if the row existed."""
     cursor = conn.execute("DELETE FROM books WHERE id = ?", (book_id,))
-    conn.commit()
     return cursor.rowcount > 0
+
+
+def insert_activity(
+    conn: sqlite3.Connection,
+    *,
+    event_type: str,
+    book_id: int,
+    book_title: str,
+    book_author: str,
+    note_id: int | None = None,
+    note_type: str | None = None,
+) -> int:
+    cursor = conn.execute(
+        """INSERT INTO activity_log
+           (event_type, book_id, note_id, book_title, book_author, note_type)
+           VALUES (?, ?, ?, ?, ?, ?)""",
+        (event_type, book_id, note_id, book_title, book_author, note_type),
+    )
+    return cursor.lastrowid
+
+
+def list_activity_rows(
+    conn: sqlite3.Connection,
+    *,
+    limit: int,
+    offset: int,
+) -> list[dict[str, Any]]:
+    rows = conn.execute(
+        """SELECT
+               activity_log.id,
+               activity_log.event_type,
+               activity_log.book_id,
+               activity_log.note_id,
+               activity_log.book_title,
+               activity_log.book_author,
+               activity_log.note_type,
+               activity_log.created_at,
+               CASE WHEN books.id IS NULL THEN 0 ELSE 1 END AS book_exists
+           FROM activity_log
+           LEFT JOIN books ON books.id = activity_log.book_id
+           ORDER BY activity_log.created_at DESC, activity_log.id DESC
+           LIMIT ? OFFSET ?""",
+        (limit, offset),
+    ).fetchall()
+    return [dict(row) for row in rows]

--- a/deploy/nginx.conf
+++ b/deploy/nginx.conf
@@ -37,6 +37,10 @@ server {
         try_files /book.html =404;
     }
 
+    location = /log {
+        try_files /log.html =404;
+    }
+
     location / {
         try_files $uri $uri/ /index.html;
     }

--- a/deploy/nginx.staging.conf
+++ b/deploy/nginx.staging.conf
@@ -37,6 +37,10 @@ server {
         try_files /book.html =404;
     }
 
+    location = /log {
+        try_files /log.html =404;
+    }
+
     location / {
         try_files $uri $uri/ /index.html;
     }

--- a/site/index.html
+++ b/site/index.html
@@ -65,6 +65,18 @@
 
     a { color: var(--accent-deep); text-decoration: none; }
 
+    .sr-only {
+      position: absolute;
+      width: 1px;
+      height: 1px;
+      padding: 0;
+      margin: -1px;
+      overflow: hidden;
+      clip: rect(0, 0, 0, 0);
+      white-space: nowrap;
+      border: 0;
+    }
+
     .container {
       max-width: 1380px;
       margin: 0 auto;
@@ -78,11 +90,26 @@
     }
 
     header .container {
+      padding: 0 24px;
+    }
+
+    .masthead {
       display: grid;
-      grid-template-columns: minmax(0, 1fr) auto;
-      gap: 20px;
+      gap: 12px;
+    }
+
+    .masthead-nav-row {
+      display: flex;
+      justify-content: flex-end;
+    }
+
+    .hero-band {
+      position: relative;
+      display: grid;
+      grid-template-columns: minmax(0, 1fr);
+      gap: 10px;
       align-items: start;
-      padding: 20px 24px 22px;
+      padding: 18px 24px 16px;
       border: 1px solid var(--border);
       border-radius: 24px;
       background:
@@ -92,7 +119,7 @@
       overflow: hidden;
     }
 
-    header .container::before {
+    .hero-band::before {
       content: "";
       position: absolute;
       inset: auto -60px -90px auto;
@@ -107,7 +134,7 @@
       display: inline-flex;
       align-items: center;
       gap: 8px;
-      margin-bottom: 10px;
+      margin-bottom: 9px;
       padding: 5px 10px;
       border: 1px solid rgba(122, 92, 62, 0.18);
       border-radius: 999px;
@@ -139,10 +166,16 @@
 
     .site-subtitle {
       margin-top: 8px;
-      max-width: 52ch;
+      max-width: 56ch;
       color: var(--muted);
       font-size: .92rem;
       line-height: 1.65;
+    }
+
+    .hero-copy {
+      min-width: 0;
+      align-self: start;
+      padding-right: 0;
     }
 
     nav {
@@ -171,6 +204,110 @@
       background: rgba(122, 92, 62, 0.08);
       color: var(--accent-deep);
       transform: translateY(-1px);
+    }
+
+    .hero-nav {
+      width: fit-content;
+      max-width: 100%;
+    }
+
+    .activity-preview {
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) auto;
+      gap: 18px;
+      align-items: start;
+      width: 100%;
+      padding-top: 18px;
+      padding-bottom: 4px;
+      border-top: 1px solid rgba(122, 92, 62, 0.1);
+    }
+
+    .activity-preview-list {
+      display: grid;
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+      gap: 18px;
+      min-width: 0;
+    }
+
+    .activity-item {
+      min-width: 0;
+      padding-left: 20px;
+      border-left: 1px solid rgba(122, 92, 62, 0.06);
+      position: relative;
+    }
+
+    .activity-item:first-child {
+      padding-left: 14px;
+      border-left: none;
+    }
+
+    .activity-dot {
+      position: absolute;
+      left: -2px;
+      top: 8px;
+      width: 4px;
+      height: 4px;
+      border-radius: 50%;
+      background: var(--accent);
+      opacity: 0.75;
+    }
+
+    .activity-item:first-child .activity-dot {
+      left: 0;
+    }
+
+    .activity-dot.is-finished { background: var(--accent); }
+    .activity-dot.is-started { background: var(--olive); }
+    .activity-dot.is-queued { background: var(--rose); }
+
+    .activity-item-title {
+      color: var(--text);
+      font-size: .9rem;
+      font-weight: 500;
+      line-height: 1.55;
+    }
+
+    a.activity-item-title {
+      color: var(--accent-deep);
+    }
+
+    a.activity-item-title:hover {
+      text-decoration: underline;
+      text-underline-offset: 2px;
+    }
+
+    .activity-item-time {
+      margin-top: 5px;
+      color: var(--muted);
+      font-size: .69rem;
+      letter-spacing: .04em;
+      text-transform: uppercase;
+    }
+
+    .activity-preview-link {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      justify-self: end;
+      align-self: start;
+      margin-top: 4px;
+      color: rgba(95, 67, 41, 0.86);
+      font-size: .78rem;
+      font-weight: 600;
+      white-space: nowrap;
+      letter-spacing: .01em;
+    }
+
+    .activity-preview-link:hover {
+      transform: translateX(1px);
+    }
+
+    .activity-preview-empty {
+      grid-column: 1 / -1;
+      color: var(--muted);
+      font-size: .84rem;
+      line-height: 1.55;
+      padding-top: 2px;
     }
 
     .section { padding: 10px 0; }
@@ -1014,8 +1151,26 @@
     }
 
     @media (max-width: 980px) {
-      header .container {
+      .masthead-nav-row {
+        justify-content: flex-start;
+      }
+
+      .hero-copy {
+        align-self: start;
+      }
+
+      .activity-preview {
         grid-template-columns: 1fr;
+        gap: 12px;
+      }
+
+      .activity-preview-list {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: 14px;
+      }
+
+      .activity-preview-link {
+        justify-self: start;
       }
 
       nav { justify-content: flex-start; }
@@ -1033,6 +1188,17 @@
       }
       .site-title { font-size: 2.3rem; }
       nav { display: none; }
+      .activity-preview {
+        width: 100%;
+        padding-top: 14px;
+      }
+      .activity-preview-list {
+        grid-template-columns: 1fr;
+        gap: 10px;
+      }
+      .activity-item {
+        padding-left: 14px;
+      }
       .book-wall { grid-template-columns: repeat(auto-fill, minmax(84px, 1fr)); gap: 8px; }
       .currently-grid { grid-template-columns: repeat(auto-fill, minmax(110px, 1fr)); gap: 10px; }
       .search-input { max-width: 100%; }
@@ -1223,20 +1389,31 @@
 </div>
 
 <header>
-  <div class="container">
-    <div>
-      <p class="site-kicker">Personal Library Archive</p>
-      <h1 class="site-title">Xinyu’s Bookshelf</h1>
-      <p class="site-subtitle">What I’ve been reading, what’s still open, and the patterns that start to appear when the shelf gets large enough.</p>
+  <div class="container masthead">
+    <div class="masthead-nav-row">
+      <nav class="hero-nav">
+        <a href="#reading-weeks">Life in weeks</a>
+        <a href="#taste-profile">Taste profile</a>
+        <a href="#read">Books read</a>
+        <a href="#currently-reading">Reading</a>
+        <a href="#to-read">Want to read</a>
+        <a href="#recommendations">AI picks</a>
+      </nav>
     </div>
-    <nav>
-      <a href="#reading-weeks">Life in weeks</a>
-      <a href="#taste-profile">Taste profile</a>
-      <a href="#read">Books read</a>
-      <a href="#currently-reading">Reading</a>
-      <a href="#to-read">Want to read</a>
-      <a href="#recommendations">AI picks</a>
-    </nav>
+    <div class="hero-band">
+      <div class="hero-copy">
+        <p class="site-kicker">Personal Library Archive</p>
+        <h1 class="site-title">Xinyu’s Bookshelf</h1>
+        <p class="site-subtitle">What I’ve been reading, what’s still open, and the patterns that start to appear when the shelf gets large enough.</p>
+      </div>
+      <aside class="activity-preview" aria-labelledby="activity-preview-title">
+        <h2 class="sr-only" id="activity-preview-title">Recent activity</h2>
+        <div class="activity-preview-list" id="activity-preview-list">
+          <p class="activity-preview-empty">Loading the latest movement on the shelf…</p>
+        </div>
+        <a class="activity-preview-link" href="log.html">View log →</a>
+      </aside>
+    </div>
   </div>
 </header>
 
@@ -1427,6 +1604,29 @@ function formatLongDate(d) {
   return date.toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' });
 }
 
+function parseDate(value, isDateOnly = false) {
+  if (!value) return null;
+  const date = new Date(isDateOnly ? `${value}T12:00:00` : value);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+function formatRelativeDate(value, isDateOnly = false) {
+  const date = parseDate(value, isDateOnly);
+  if (!date) return '';
+
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const dayMs = 24 * 60 * 60 * 1000;
+  const days = Math.floor(diffMs / dayMs);
+
+  if (days <= 0) return 'Today';
+  if (days === 1) return 'Yesterday';
+  if (days < 7) return `${days} days ago`;
+  if (days < 30) return `${Math.floor(days / 7)} week${Math.floor(days / 7) === 1 ? '' : 's'} ago`;
+  if (days < 365) return `${Math.floor(days / 30)} month${Math.floor(days / 30) === 1 ? '' : 's'} ago`;
+  return `${Math.floor(days / 365)} year${Math.floor(days / 365) === 1 ? '' : 's'} ago`;
+}
+
 function escHtml(str) {
   return String(str || '')
     .replace(/&/g, '&amp;')
@@ -1434,6 +1634,32 @@ function escHtml(str) {
     .replace(/>/g, '&gt;')
     .replace(/"/g, '&quot;')
     .replace(/'/g, '&#39;');
+}
+
+function activityClass(eventType) {
+  if (eventType === 'started_reading') return 'is-started';
+  if (eventType === 'book_added_to_to_read') return 'is-queued';
+  return '';
+}
+
+function renderActivityPreview(payload) {
+  const list = document.getElementById('activity-preview-list');
+  const items = Array.isArray(payload && payload.items) ? payload.items : [];
+
+  if (!items.length) {
+    list.innerHTML = '<p class="activity-preview-empty">No recent movement yet. The archive is quiet for now.</p>';
+    return;
+  }
+
+  list.innerHTML = items.map(item => `
+    <article class="activity-item">
+      <span class="activity-dot ${activityClass(item.event_type)}" aria-hidden="true"></span>
+      ${item.book && item.book.href
+        ? `<a class="activity-item-title" href="${escHtml(item.book.href)}">${escHtml(item.summary)}</a>`
+        : `<p class="activity-item-title">${escHtml(item.summary)}</p>`}
+      <p class="activity-item-time">${escHtml(formatRelativeDate(item.created_at))}</p>
+    </article>
+  `).join('');
 }
 
 function buildCoverHtml(book) {
@@ -1900,11 +2126,12 @@ async function fetchJson(url) {
 }
 
 async function load() {
-  const [booksResult, tasteResult, recommendationsResult, healthResult] = await Promise.allSettled([
+  const [booksResult, tasteResult, recommendationsResult, healthResult, activityResult] = await Promise.allSettled([
     fetchJson('/api/books'),
     fetchJson('/api/taste-profile'),
     fetchJson('/api/recommendations'),
     fetchJson('/api/health'),
+    fetchJson('/api/activity?limit=3'),
   ]);
 
   if (booksResult.status !== 'fulfilled') {
@@ -1924,6 +2151,7 @@ async function load() {
   const { books, stats, generated_at } = data;
 
   allReadBooks = books.read || [];
+  renderActivityPreview(activityResult.status === 'fulfilled' ? activityResult.value : { items: [] });
   buildShelfTags(allReadBooks);
   applyHash();
   renderReadGrid();

--- a/site/log.html
+++ b/site/log.html
@@ -1,0 +1,349 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Reading Log — Xinyu's Bookshelf</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@500;600;700&family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    :root {
+      --bg: #f4efe6;
+      --surface: rgba(255, 251, 245, 0.84);
+      --surface-strong: #fffaf3;
+      --border: rgba(122, 92, 62, 0.16);
+      --muted: #7c7267;
+      --text: #261f18;
+      --accent: #7a5c3e;
+      --accent-deep: #5f4329;
+      --olive: #5e6954;
+      --rose: #8c5d58;
+      --shadow-soft: 0 18px 50px rgba(61, 42, 22, 0.08);
+    }
+
+    body {
+      font-family: 'Inter', system-ui, sans-serif;
+      background:
+        radial-gradient(circle at top, rgba(255, 248, 238, 0.94), transparent 34%),
+        linear-gradient(180deg, #f8f4ed 0%, var(--bg) 35%, #efe7da 100%);
+      color: var(--text);
+      font-size: 15px;
+      line-height: 1.6;
+      min-height: 100vh;
+    }
+
+    a { color: var(--accent-deep); text-decoration: none; }
+    a:hover { color: var(--accent); }
+
+    .hidden { display: none !important; }
+
+    .container {
+      max-width: 980px;
+      margin: 0 auto;
+      padding: 24px;
+    }
+
+    .back {
+      display: inline-block;
+      margin-bottom: 16px;
+      color: var(--muted);
+      font-size: .84rem;
+    }
+
+    .hero,
+    .log-shell {
+      border: 1px solid var(--border);
+      border-radius: 24px;
+      background:
+        linear-gradient(180deg, rgba(255, 252, 247, 0.9), rgba(247, 240, 230, 0.8)),
+        var(--surface-strong);
+      box-shadow: var(--shadow-soft);
+    }
+
+    .hero {
+      padding: 24px;
+      margin-bottom: 12px;
+    }
+
+    .kicker {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      margin-bottom: 10px;
+      padding: 5px 10px;
+      border: 1px solid rgba(122, 92, 62, 0.18);
+      border-radius: 999px;
+      background: rgba(255, 250, 242, 0.75);
+      color: var(--accent-deep);
+      font-size: .62rem;
+      font-weight: 700;
+      letter-spacing: .12em;
+      text-transform: uppercase;
+    }
+
+    .kicker::before {
+      content: "";
+      width: 6px;
+      height: 6px;
+      border-radius: 50%;
+      background: var(--accent);
+    }
+
+    h1 {
+      font-family: 'Cormorant Garamond', 'Times New Roman', serif;
+      font-size: clamp(2.2rem, 5vw, 3.4rem);
+      line-height: .96;
+      letter-spacing: -.04em;
+      font-weight: 600;
+    }
+
+    .subtitle {
+      margin-top: 10px;
+      max-width: 54ch;
+      color: var(--muted);
+      font-size: .94rem;
+    }
+
+    .log-shell {
+      padding: 16px 20px 18px;
+    }
+
+    .log-list {
+      display: grid;
+      gap: 0;
+    }
+
+    .log-item {
+      display: grid;
+      grid-template-columns: 16px minmax(0, 1fr);
+      gap: 12px;
+      padding: 18px 0;
+      border-top: 1px solid rgba(122, 92, 62, 0.08);
+    }
+
+    .log-item:first-child {
+      border-top: none;
+      padding-top: 4px;
+    }
+
+    .log-dot {
+      width: 6px;
+      height: 6px;
+      margin-top: 8px;
+      border-radius: 50%;
+      background: var(--accent);
+      opacity: 0.78;
+    }
+
+    .log-dot.is-started { background: var(--olive); }
+    .log-dot.is-queued { background: var(--rose); }
+
+    .log-summary {
+      font-size: 1rem;
+      line-height: 1.6;
+      color: var(--text);
+      font-weight: 500;
+    }
+
+    a.log-summary {
+      color: var(--accent-deep);
+    }
+
+    a.log-summary:hover {
+      text-decoration: underline;
+      text-underline-offset: 2px;
+    }
+
+    .log-time {
+      margin-top: 4px;
+      color: var(--muted);
+      font-size: .74rem;
+      letter-spacing: .03em;
+      text-transform: uppercase;
+    }
+
+    .empty,
+    .error {
+      padding: 6px 0 2px;
+      color: var(--muted);
+    }
+
+    .error { color: var(--rose); }
+
+    .load-more-wrap {
+      display: flex;
+      justify-content: center;
+      padding-top: 16px;
+    }
+
+    .btn {
+      padding: 10px 18px;
+      border: 1px solid var(--border);
+      border-radius: 999px;
+      background: rgba(255, 255, 255, 0.72);
+      color: var(--accent-deep);
+      font: inherit;
+      font-size: .84rem;
+      font-weight: 600;
+      cursor: pointer;
+      transition: background .18s ease, transform .18s ease;
+    }
+
+    .btn:hover:not(:disabled) {
+      background: rgba(122, 92, 62, 0.08);
+      transform: translateY(-1px);
+    }
+
+    .btn:disabled {
+      opacity: 0.6;
+      cursor: default;
+      transform: none;
+    }
+
+    @media (max-width: 640px) {
+      .container {
+        padding: 18px;
+      }
+
+      .hero,
+      .log-shell {
+        border-radius: 20px;
+      }
+
+      .hero {
+        padding: 20px 18px;
+      }
+
+      .log-shell {
+        padding: 14px 16px 16px;
+      }
+
+      .log-item {
+        grid-template-columns: 12px minmax(0, 1fr);
+        gap: 10px;
+      }
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <a class="back" href="index.html">&larr; Back to bookshelf</a>
+
+    <section class="hero">
+      <p class="kicker">Reading Log</p>
+      <h1>What changed on the shelf</h1>
+      <p class="subtitle">A running record of new books, shelf moves, and notes as they happen.</p>
+    </section>
+
+    <section class="log-shell" aria-labelledby="log-title">
+      <h2 id="log-title" style="position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0;">Reading log entries</h2>
+      <div class="log-list" id="log-list">
+        <p class="empty">Loading the latest movement on the shelf…</p>
+      </div>
+      <div class="load-more-wrap">
+        <button class="btn hidden" id="load-more-btn" type="button">Load more</button>
+      </div>
+    </section>
+  </div>
+
+  <script>
+    const isLocalHost = location.hostname === 'localhost' || location.hostname === '127.0.0.1';
+    const localApiPort = location.port === '8010' ? '8011' : '8001';
+    const apiBase = isLocalHost ? `http://127.0.0.1:${localApiPort}` : '';
+    const state = { limit: 30, offset: 0, hasMore: false, loading: false };
+
+    function escHtml(str) {
+      return String(str || '')
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+    }
+
+    function formatAbsoluteDate(value) {
+      if (!value) return '';
+      const date = new Date(value);
+      if (Number.isNaN(date.getTime())) return value;
+      return date.toLocaleString('en-US', {
+        year: 'numeric',
+        month: 'long',
+        day: 'numeric',
+        hour: 'numeric',
+        minute: '2-digit',
+      });
+    }
+
+    function itemClass(eventType) {
+      if (eventType === 'started_reading') return 'is-started';
+      if (eventType === 'book_added_to_to_read') return 'is-queued';
+      return '';
+    }
+
+    function renderItems(items, append = false) {
+      const list = document.getElementById('log-list');
+      if (!append) list.innerHTML = '';
+
+      if (!append && !items.length) {
+        list.innerHTML = '<p class="empty">No recent changes yet. The log will start filling as new activity happens.</p>';
+        return;
+      }
+
+      const html = items.map(item => `
+        <article class="log-item">
+          <span class="log-dot ${itemClass(item.event_type)}" aria-hidden="true"></span>
+          <div>
+            ${item.book && item.book.href
+              ? `<a class="log-summary" href="${escHtml(item.book.href)}">${escHtml(item.summary)}</a>`
+              : `<p class="log-summary">${escHtml(item.summary)}</p>`}
+            <p class="log-time">${escHtml(formatAbsoluteDate(item.created_at))}</p>
+          </div>
+        </article>
+      `).join('');
+
+      if (append) list.insertAdjacentHTML('beforeend', html);
+      else list.innerHTML = html;
+    }
+
+    function setLoadMoreVisible(visible) {
+      document.getElementById('load-more-btn').classList.toggle('hidden', !visible);
+    }
+
+    async function fetchPage(offset, append = false) {
+      if (state.loading) return;
+      state.loading = true;
+      const button = document.getElementById('load-more-btn');
+      button.disabled = true;
+
+      try {
+        const response = await fetch(`${apiBase}/api/activity?limit=${state.limit}&offset=${offset}`);
+        if (!response.ok) throw new Error(`HTTP ${response.status}`);
+        const payload = await response.json();
+        renderItems(payload.items || [], append);
+        state.offset = payload.pagination && typeof payload.pagination.next_offset === 'number'
+          ? payload.pagination.next_offset
+          : offset + (payload.items || []).length;
+        state.hasMore = Boolean(payload.pagination && payload.pagination.has_more);
+        setLoadMoreVisible(state.hasMore);
+      } catch (error) {
+        if (!append) {
+          document.getElementById('log-list').innerHTML =
+            `<p class="error">Could not load the reading log right now.</p>`;
+        }
+      } finally {
+        state.loading = false;
+        button.disabled = false;
+      }
+    }
+
+    document.getElementById('load-more-btn').addEventListener('click', () => {
+      fetchPage(state.offset, true);
+    });
+
+    fetchPage(0);
+  </script>
+</body>
+</html>

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -113,6 +113,13 @@ class ApiTests(unittest.TestCase):
         self.assertTrue(payload["has_taste_profile"])
         self.assertTrue(payload["has_recommendations"])
 
+    def test_activity_endpoint_returns_empty_on_json_backend(self):
+        response = self.client.get("/api/activity")
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertEqual(payload["items"], [])
+        self.assertFalse(payload["pagination"]["has_more"])
+
     def test_sync_endpoint_returns_410_gone(self):
         response = self.client.post("/api/sync")
         self.assertEqual(response.status_code, 410)

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -13,6 +13,7 @@ from unittest.mock import AsyncMock, patch
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
 
+import db as db_module
 from bookshelf_data import (
     BookshelfDB,
     BookshelfStore,
@@ -27,6 +28,7 @@ from db import (
     get_llm_cache_value,
     get_schema_version,
     insert_book,
+    list_activity_rows,
     run_migrations,
     set_llm_cache_value,
     update_book,
@@ -256,20 +258,74 @@ class DbSchemaTests(unittest.TestCase):
         self.assertIn("books", tables)
         self.assertIn("llm_cache", tables)
         self.assertIn("auth_tokens", tables)
+        self.assertIn("notes", tables)
+        self.assertIn("activity_log", tables)
         self.assertIn("schema_version", tables)
         conn.close()
 
-    def test_schema_version_is_1(self):
+    def test_schema_version_is_2(self):
         conn = get_connection(self.db_path)
         run_migrations(conn)
-        self.assertEqual(get_schema_version(conn), 1)
+        self.assertEqual(get_schema_version(conn), 2)
         conn.close()
 
     def test_migrations_are_idempotent(self):
         conn = get_connection(self.db_path)
         run_migrations(conn)
         run_migrations(conn)
-        self.assertEqual(get_schema_version(conn), 1)
+        self.assertEqual(get_schema_version(conn), 2)
+        conn.close()
+
+    def test_existing_notes_table_upgrades_cleanly(self):
+        conn = get_connection(self.db_path)
+        db_module._migration_v1(conn)
+        conn.executescript(db_module._NOTES_SCHEMA)
+        conn.execute(
+            """CREATE TABLE IF NOT EXISTS schema_version (
+                version INTEGER PRIMARY KEY,
+                applied_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+            )"""
+        )
+        conn.execute("INSERT INTO schema_version (version) VALUES (1)")
+        conn.commit()
+
+        applied = run_migrations(conn)
+        tables = {
+            row[0]
+            for row in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table'"
+            ).fetchall()
+        }
+
+        self.assertEqual(applied, 1)
+        self.assertEqual(get_schema_version(conn), 2)
+        self.assertIn("notes", tables)
+        self.assertIn("activity_log", tables)
+        conn.close()
+
+    def test_insert_and_list_activity_rows(self):
+        conn = get_connection(self.db_path)
+        run_migrations(conn)
+        book_id = insert_book(conn, {
+            "title": "Test Book",
+            "author": "Test Author",
+            "date_added": "2026-01-01",
+            "exclusive_shelf": "to_read",
+        })
+        db_module.insert_activity(
+            conn,
+            event_type="book_added_to_to_read",
+            book_id=book_id,
+            book_title="Test Book",
+            book_author="Test Author",
+        )
+        conn.commit()
+
+        rows = list_activity_rows(conn, limit=10, offset=0)
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["event_type"], "book_added_to_to_read")
+        self.assertEqual(rows[0]["book_title"], "Test Book")
+        self.assertEqual(rows[0]["book_exists"], 1)
         conn.close()
 
     def test_insert_and_retrieve_book(self):
@@ -581,6 +637,13 @@ class ApiSqliteTests(unittest.TestCase):
         self.assertTrue(data["has_taste_profile"])
         self.assertEqual(data["data_backend"], "sqlite")
 
+    def test_activity_endpoint_empty_initially(self):
+        resp = self.client.get("/api/activity")
+        self.assertEqual(resp.status_code, 200)
+        payload = resp.json()
+        self.assertEqual(payload["items"], [])
+        self.assertFalse(payload["pagination"]["has_more"])
+
     def test_llm_status_endpoint(self):
         resp = self.client.get("/api/llm-status")
         self.assertEqual(resp.status_code, 200)
@@ -613,6 +676,27 @@ class ApiSqliteTests(unittest.TestCase):
         self.assertEqual(data["author"], "New Author")
         self.assertEqual(data["shelves"], ["to-read"])
 
+    def test_create_book_logs_activity_for_each_initial_shelf(self):
+        cases = [
+            ("Shelf One", "to_read", "book_added_to_to_read", "Added Shelf One to to-read"),
+            ("Shelf Two", "currently_reading", "started_reading", "Started Shelf Two"),
+            ("Shelf Three", "read", "finished_reading", "Finished Shelf Three"),
+        ]
+
+        for title, shelf, _, _ in cases:
+            resp = self.client.post(
+                "/api/books",
+                json={"title": title, "author": "Author", "exclusive_shelf": shelf},
+                headers=TEST_AUTH_HEADER,
+            )
+            self.assertEqual(resp.status_code, 201)
+
+        activity = self.client.get("/api/activity?limit=10").json()["items"]
+        self.assertEqual(len(activity), 3)
+        for item, (_, _, event_type, summary) in zip(activity, reversed(cases)):
+            self.assertEqual(item["event_type"], event_type)
+            self.assertEqual(item["summary"], summary)
+
     def test_create_book_requires_auth(self):
         resp = self.client.post(
             "/api/books",
@@ -627,6 +711,7 @@ class ApiSqliteTests(unittest.TestCase):
             headers=TEST_AUTH_HEADER,
         )
         self.assertEqual(resp.status_code, 422)
+        self.assertEqual(self.client.get("/api/activity").json()["items"], [])
 
     def test_update_book(self):
         # Create a book first
@@ -644,6 +729,51 @@ class ApiSqliteTests(unittest.TestCase):
         )
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(resp.json()["title"], "New Title")
+
+    def test_update_book_logs_when_entering_currently_reading_or_read(self):
+        resp = self.client.post(
+            "/api/books",
+            json={"title": "Transition Book", "author": "Author", "exclusive_shelf": "to_read"},
+            headers=TEST_AUTH_HEADER,
+        )
+        book_id = resp.json()["id"]
+
+        self.client.put(
+            f"/api/books/{book_id}",
+            json={"exclusive_shelf": "currently_reading"},
+            headers=TEST_AUTH_HEADER,
+        )
+        self.client.put(
+            f"/api/books/{book_id}",
+            json={"exclusive_shelf": "read"},
+            headers=TEST_AUTH_HEADER,
+        )
+
+        activity = self.client.get("/api/activity?limit=10").json()["items"]
+        self.assertEqual([item["event_type"] for item in activity], [
+            "finished_reading",
+            "started_reading",
+            "book_added_to_to_read",
+        ])
+
+    def test_metadata_only_book_edit_creates_no_activity(self):
+        resp = self.client.post(
+            "/api/books",
+            json={"title": "Quiet Book", "author": "Author", "exclusive_shelf": "to_read"},
+            headers=TEST_AUTH_HEADER,
+        )
+        book_id = resp.json()["id"]
+
+        resp = self.client.put(
+            f"/api/books/{book_id}",
+            json={"title": "Quiet Book Revised"},
+            headers=TEST_AUTH_HEADER,
+        )
+        self.assertEqual(resp.status_code, 200)
+
+        activity = self.client.get("/api/activity?limit=10").json()["items"]
+        self.assertEqual(len(activity), 1)
+        self.assertEqual(activity[0]["event_type"], "book_added_to_to_read")
 
     def test_update_book_normalizes_shelves(self):
         resp = self.client.post(
@@ -691,6 +821,40 @@ class ApiSqliteTests(unittest.TestCase):
         )
         self.assertEqual(resp.status_code, 404)
 
+    def test_activity_pagination(self):
+        titles = ["First", "Second", "Third", "Fourth"]
+        for title in titles:
+            resp = self.client.post(
+                "/api/books",
+                json={"title": title, "author": "Author", "exclusive_shelf": "to_read"},
+                headers=TEST_AUTH_HEADER,
+            )
+            self.assertEqual(resp.status_code, 201)
+
+        first_page = self.client.get("/api/activity?limit=3&offset=0").json()
+        second_page = self.client.get("/api/activity?limit=3&offset=3").json()
+
+        self.assertEqual(len(first_page["items"]), 3)
+        self.assertTrue(first_page["pagination"]["has_more"])
+        self.assertEqual(first_page["pagination"]["next_offset"], 3)
+        self.assertEqual(first_page["items"][0]["summary"], "Added Fourth to to-read")
+        self.assertEqual(len(second_page["items"]), 1)
+        self.assertFalse(second_page["pagination"]["has_more"])
+        self.assertEqual(second_page["items"][0]["summary"], "Added First to to-read")
+
+    def test_deleted_book_activity_has_null_href(self):
+        create = self.client.post(
+            "/api/books",
+            json={"title": "Transient Book", "author": "Author", "exclusive_shelf": "to_read"},
+            headers=TEST_AUTH_HEADER,
+        )
+        book_id = create.json()["id"]
+        self.client.delete(f"/api/books/{book_id}", headers=TEST_AUTH_HEADER)
+
+        activity = self.client.get("/api/activity?limit=10").json()["items"]
+        self.assertEqual(activity[0]["summary"], "Added Transient Book to to-read")
+        self.assertIsNone(activity[0]["book"]["href"])
+
     def test_lookup_endpoint(self):
         mock_results = [{"title": "Dune", "author": "Frank Herbert", "google_books_id": "abc"}]
         with patch("api.google_books.search_books", new_callable=AsyncMock, return_value=mock_results):
@@ -718,6 +882,53 @@ class ApiSqliteTests(unittest.TestCase):
             headers={"Authorization": "Bearer bad-token"},
         )
         self.assertEqual(resp.status_code, 401)
+
+    def test_create_note_logs_note_added(self):
+        resp = self.client.post(
+            "/api/books/1/notes",
+            json={"note_type": "quote", "content": "The sleeper must awaken."},
+            headers=TEST_AUTH_HEADER,
+        )
+        self.assertEqual(resp.status_code, 201)
+
+        activity = self.client.get("/api/activity?limit=10").json()["items"]
+        self.assertEqual(len(activity), 1)
+        self.assertEqual(activity[0]["event_type"], "note_added")
+        self.assertEqual(activity[0]["note_type"], "quote")
+        self.assertEqual(activity[0]["summary"], "Added a quote from Dune")
+
+    def test_note_update_and_delete_do_not_log_activity(self):
+        create = self.client.post(
+            "/api/books/1/notes",
+            json={"note_type": "thought", "content": "First note."},
+            headers=TEST_AUTH_HEADER,
+        )
+        note_id = create.json()["id"]
+
+        update = self.client.put(
+            f"/api/books/1/notes/{note_id}",
+            json={"note_type": "thought", "content": "Updated note."},
+            headers=TEST_AUTH_HEADER,
+        )
+        delete = self.client.delete(
+            f"/api/books/1/notes/{note_id}",
+            headers=TEST_AUTH_HEADER,
+        )
+
+        self.assertEqual(update.status_code, 200)
+        self.assertEqual(delete.status_code, 200)
+        activity = self.client.get("/api/activity?limit=10").json()["items"]
+        self.assertEqual(len(activity), 1)
+        self.assertEqual(activity[0]["event_type"], "note_added")
+
+    def test_failed_note_creation_does_not_log_activity(self):
+        resp = self.client.post(
+            "/api/books/99999/notes",
+            json={"note_type": "thought", "content": "Ghost note."},
+            headers=TEST_AUTH_HEADER,
+        )
+        self.assertEqual(resp.status_code, 404)
+        self.assertEqual(self.client.get("/api/activity").json()["items"], [])
 
 
 # ── Tests: Migration script ───────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- add an append-only SQLite-backed activity log and public `/api/activity` feed
- surface recent shelf activity in the homepage hero and add a new public `/log` page
- log milestone-only events for book creation, shelf transitions into reading/read, and new notes

## Why
The homepage felt too static between book completions. This adds a truthful, lightweight activity layer so visitors can see that the shelf is being actively maintained.

## User impact
- the homepage now shows up to three recent activity items in the hero band
- a new `/log` page shows the full public reading log with pagination
- activity starts fresh from launch and intentionally avoids noisy edit/delete events

## Validation
- `./.venv/bin/python -m unittest tests.test_api tests.test_db`
- local browser sanity check for the homepage empty state and `/log` empty state

Closes #19
