### PR TITLE
[codex] Refine connection notes and add external links

### DIFF
--- a/api/notes.py
+++ b/api/notes.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 from typing import Any
+from urllib.parse import urlparse
 
 from fastapi import APIRouter, HTTPException, Request
 
@@ -38,13 +39,50 @@ def _validate_note_body(body: dict[str, Any]) -> dict[str, Any]:
         if not isinstance(tags, list) or not all(isinstance(t, str) for t in tags):
             raise HTTPException(status_code=422, detail="tags must be a list of strings.")
 
-    connected_source_id = body.get("connected_source_id")
-    connected_source_type = "book" if connected_source_id is not None else None
+    connected_label = (body.get("connected_label") or "").strip() or None
+    connected_url = (body.get("connected_url") or "").strip() or None
+    raw_connected_source_id = body.get("connected_source_id")
+    connected_source_id = None
+    if raw_connected_source_id not in (None, ""):
+        try:
+            connected_source_id = int(raw_connected_source_id)
+        except (TypeError, ValueError):
+            raise HTTPException(
+                status_code=422,
+                detail="connected_source_id must be a valid book id.",
+            )
+
+    if connected_url is not None:
+        parsed_url = urlparse(connected_url)
+        if parsed_url.scheme not in {"http", "https"} or not parsed_url.netloc:
+            raise HTTPException(
+                status_code=422,
+                detail="connected_url must be a valid http or https URL.",
+            )
+
+    if note_type != "connection":
+        connected_source_id = None
+        connected_label = None
+        connected_url = None
+        connected_source_type = None
+    elif connected_source_id is not None:
+        connected_label = None
+        connected_url = None
+        connected_source_type = "book"
+    else:
+        if connected_label is None:
+            raise HTTPException(
+                status_code=422,
+                detail="connection notes require a connected book or label.",
+            )
+        connected_source_type = None
 
     return {
         "note_type": note_type,
         "content": content,
         "page_or_location": body.get("page_or_location"),
+        "connected_label": connected_label,
+        "connected_url": connected_url,
         "connected_source_type": connected_source_type,
         "connected_source_id": connected_source_id,
         "tags": json.dumps(tags, ensure_ascii=False) if tags is not None else None,
@@ -60,6 +98,8 @@ def _row_to_note(row: dict[str, Any]) -> dict[str, Any]:
         "note_type": row["note_type"],
         "content": row["content"],
         "page_or_location": row["page_or_location"],
+        "connected_label": row.get("connected_label"),
+        "connected_url": row.get("connected_url"),
         "connected_source_type": row["connected_source_type"],
         "connected_source_id": row["connected_source_id"],
         "connected_book": None,
@@ -131,16 +171,28 @@ async def create_note(book_id: int, request: Request) -> dict:
     body = await request.json()
     fields = _validate_note_body(body)
 
+    if fields["note_type"] == "connection" and fields["connected_source_id"] is not None:
+        connected_book = conn.execute(
+            "SELECT id FROM books WHERE id = ?",
+            (fields["connected_source_id"],),
+        ).fetchone()
+        if connected_book is None:
+            raise HTTPException(status_code=422, detail="Connected book not found.")
+        if connected_book["id"] == book["id"]:
+            raise HTTPException(status_code=422, detail="A note cannot connect a book to itself.")
+
     try:
         cursor = conn.execute(
             """INSERT INTO notes (source_type, source_id, note_type, content,
-               page_or_location, connected_source_type, connected_source_id, tags)
-               VALUES ('book', ?, ?, ?, ?, ?, ?, ?)""",
+               page_or_location, connected_label, connected_url, connected_source_type, connected_source_id, tags)
+               VALUES ('book', ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
             (
                 book_id,
                 fields["note_type"],
                 fields["content"],
                 fields["page_or_location"],
+                fields["connected_label"],
+                fields["connected_url"],
                 fields["connected_source_type"],
                 fields["connected_source_id"],
                 fields["tags"],
@@ -182,16 +234,28 @@ async def update_note(book_id: int, note_id: int, request: Request) -> dict:
     body = await request.json()
     fields = _validate_note_body(body)
 
+    if fields["note_type"] == "connection" and fields["connected_source_id"] is not None:
+        connected_book = conn.execute(
+            "SELECT id FROM books WHERE id = ?",
+            (fields["connected_source_id"],),
+        ).fetchone()
+        if connected_book is None:
+            raise HTTPException(status_code=422, detail="Connected book not found.")
+        if connected_book["id"] == book_id:
+            raise HTTPException(status_code=422, detail="A note cannot connect a book to itself.")
+
     try:
         conn.execute(
             """UPDATE notes SET note_type = ?, content = ?, page_or_location = ?,
-               connected_source_type = ?, connected_source_id = ?, tags = ?,
+               connected_label = ?, connected_url = ?, connected_source_type = ?, connected_source_id = ?, tags = ?,
                updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now')
                WHERE id = ?""",
             (
                 fields["note_type"],
                 fields["content"],
                 fields["page_or_location"],
+                fields["connected_label"],
+                fields["connected_url"],
                 fields["connected_source_type"],
                 fields["connected_source_id"],
                 fields["tags"],

--- a/db.py
+++ b/db.py
@@ -75,6 +75,8 @@ CREATE TABLE IF NOT EXISTS notes (
         CHECK (note_type IN ('thought', 'quote', 'connection', 'disagreement', 'question')),
     content TEXT NOT NULL,
     page_or_location TEXT,
+    connected_label TEXT,
+    connected_url TEXT,
     connected_source_type TEXT,
     connected_source_id INTEGER,
     tags TEXT,
@@ -113,11 +115,31 @@ def _migration_v2(conn: sqlite3.Connection) -> None:
     conn.executescript(_ACTIVITY_LOG_SCHEMA)
 
 
+def _migration_v3(conn: sqlite3.Connection) -> None:
+    note_columns = {
+        row["name"]
+        for row in conn.execute("PRAGMA table_info(notes)").fetchall()
+    }
+    if "connected_label" not in note_columns:
+        conn.execute("ALTER TABLE notes ADD COLUMN connected_label TEXT")
+
+
+def _migration_v4(conn: sqlite3.Connection) -> None:
+    note_columns = {
+        row["name"]
+        for row in conn.execute("PRAGMA table_info(notes)").fetchall()
+    }
+    if "connected_url" not in note_columns:
+        conn.execute("ALTER TABLE notes ADD COLUMN connected_url TEXT")
+
+
 # ── Migration registry ────────────────────────────────────────────────────────
 
 MIGRATIONS: list[tuple[int, Callable[[sqlite3.Connection], None]]] = [
     (1, _migration_v1),
     (2, _migration_v2),
+    (3, _migration_v3),
+    (4, _migration_v4),
 ]
 
 

--- a/scripts/add_notes_table.py
+++ b/scripts/add_notes_table.py
@@ -21,6 +21,8 @@ CREATE TABLE IF NOT EXISTS notes (
         CHECK (note_type IN ('thought', 'quote', 'connection', 'disagreement', 'question')),
     content TEXT NOT NULL,
     page_or_location TEXT,
+    connected_label TEXT,
+    connected_url TEXT,
     connected_source_type TEXT,
     connected_source_id INTEGER,
     tags TEXT,

--- a/site/book.html
+++ b/site/book.html
@@ -137,22 +137,43 @@
       border-left: 3px solid var(--question-accent); padding-left: 14px;
     }
 
-    /* Connection card */
-    .connected-card {
-      display: inline-flex; align-items: center; gap: 10px;
-      padding: 8px 12px; border-radius: 10px;
-      border: 1px solid var(--border); background: rgba(255,255,255,0.86);
-      margin-bottom: 8px; text-decoration: none; color: var(--text);
-      transition: background .14s;
+    /* Connection reference */
+    .connected-reference {
+      display: inline-flex; align-items: baseline; flex-wrap: wrap; gap: 6px;
+      margin: 1px 0 10px; color: var(--olive); font-size: .88rem; line-height: 1.45;
     }
-    .connected-card:hover { background: var(--accent-soft); }
-    .connected-cover {
-      width: 32px; height: 48px; border-radius: 4px; overflow: hidden;
-      background: var(--bg-wash); flex-shrink: 0;
+    .connected-reference::before {
+      content: "";
+      width: 6px; height: 6px; border-radius: 999px; flex-shrink: 0;
+      background: rgba(104, 115, 93, 0.34); transform: translateY(-1px);
     }
-    .connected-cover img { width: 100%; height: 100%; object-fit: cover; }
-    .connected-title { font-size: .82rem; font-weight: 600; line-height: 1.2; }
-    .connected-author { font-size: .75rem; color: var(--muted); }
+    .connected-reference-title {
+      font-weight: 600;
+      color: rgba(82, 74, 63, 0.92);
+    }
+    a.connected-reference {
+      color: inherit; text-decoration: none;
+    }
+    a.connected-reference .connected-reference-title {
+      border-bottom: 1px solid rgba(120, 86, 65, 0.2);
+      transition: color .14s, border-color .14s;
+    }
+    a.connected-reference:hover .connected-reference-title {
+      color: var(--accent-deep);
+      border-color: rgba(120, 86, 65, 0.38);
+    }
+    .connected-reference-meta {
+      font-size: .81rem; color: var(--muted);
+    }
+    .connected-reference-external {
+      color: var(--accent-deep);
+      border-bottom: 1px solid rgba(120, 86, 65, 0.16);
+      text-decoration: none;
+    }
+    .connected-reference-external:hover {
+      color: var(--accent);
+      border-color: rgba(120, 86, 65, 0.34);
+    }
 
     .note-tags { display: flex; flex-wrap: wrap; gap: 4px; margin-top: 6px; }
     .note-tag {
@@ -200,6 +221,11 @@
     .note-form select, .note-form input, .note-form textarea {
       width: 100%; padding: 9px 12px; border: 1px solid var(--border); border-radius: 10px;
       background: rgba(255,255,255,0.88); font-size: .94rem; font-family: inherit; color: var(--text);
+    }
+    .note-form input:disabled {
+      background: rgba(244, 238, 231, 0.9);
+      color: var(--muted);
+      cursor: not-allowed;
     }
     .note-form select:focus, .note-form input:focus, .note-form textarea:focus {
       outline: none; border-color: rgba(122,92,62,0.42); box-shadow: 0 0 0 3px rgba(122,92,62,0.08);
@@ -253,6 +279,12 @@
       cursor: pointer; padding: 0; line-height: 1;
     }
     .connect-chip button:hover { color: var(--accent-deep); }
+    .connect-extra-field { margin-top: 10px; }
+    .field-hint {
+      margin-top: 4px;
+      font-size: .76rem;
+      color: var(--muted);
+    }
 
     /* Tags toggle */
     .tags-toggle {
@@ -308,6 +340,13 @@ let currentNotes = [];
 function getToken() { return localStorage.getItem(AUTH_KEY) || ''; }
 function isAuth() { return !!getToken(); }
 function escHtml(s) { const d = document.createElement('div'); d.textContent = s; return d.innerHTML; }
+function escAttr(s) {
+  return String(s)
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
 
 function stars(rating) {
   let html = '';
@@ -336,7 +375,7 @@ const RESERVED_SHELF_TAGS = new Set(['read', 'currently-reading', 'to-read']);
 const PLACEHOLDERS = {
   thought: 'What stuck with you, what you\'d tell a friend...',
   quote: 'Enter the exact passage...',
-  connection: 'How does this connect to the other book...',
+  connection: 'How does this connect to the other work...',
   disagreement: 'What do you push back on and why...',
   question: 'What\'s left unresolved...',
 };
@@ -385,9 +424,6 @@ function renderNoteHtml(note) {
     disagreement: 'Disagreement', question: 'Question',
   };
   let label = typeLabels[note.note_type] || note.note_type;
-  if (note.note_type === 'connection' && note.connected_book) {
-    label += ` &rarr; ${escHtml(note.connected_book.title)}`;
-  }
   if (note.note_type === 'question') label = '? ' + label;
 
   const locationHtml = note.page_or_location
@@ -397,16 +433,19 @@ function renderNoteHtml(note) {
   let connectedHtml = '';
   if (note.note_type === 'connection' && note.connected_book) {
     const cb = note.connected_book;
-    const coverImg = cb.cover_url
-      ? `<img src="${escHtml(cb.cover_url)}" alt="${escHtml(cb.title)}">` : '';
     connectedHtml = `
-      <a class="connected-card" href="book.html?id=${cb.id}">
-        <div class="connected-cover">${coverImg}</div>
-        <div>
-          <div class="connected-title">${escHtml(cb.title)}</div>
-          <div class="connected-author">${escHtml(cb.author)}</div>
-        </div>
+      <a class="connected-reference" href="book.html?id=${cb.id}">
+        <span class="connected-reference-title">${escHtml(cb.title)}</span>
+        <span class="connected-reference-meta">${escHtml(cb.author)}</span>
       </a>`;
+  } else if (note.note_type === 'connection' && note.connected_label) {
+    const externalTargetHtml = note.connected_url
+      ? `<a class="connected-reference-external" href="${escAttr(note.connected_url)}" target="_blank" rel="noopener noreferrer">${escHtml(note.connected_label)}</a>`
+      : `<span class="connected-reference-title">${escHtml(note.connected_label)}</span>`;
+    connectedHtml = `
+      <div class="connected-reference">
+        ${externalTargetHtml}
+      </div>`;
   }
 
   const tagsHtml = (note.tags && note.tags.length)
@@ -450,13 +489,28 @@ function renderNotes(notes) {
 // ── Note form builder (shared by add & edit) ────────────────────────────────
 
 function buildNoteFormHtml(opts = {}) {
-  const { noteType = 'thought', content = '', pageOrLocation = '', connectedId = null, connectedBook = null, tags = [], formId = 'add' } = opts;
+  const {
+    noteType = 'thought',
+    content = '',
+    pageOrLocation = '',
+    connectedId = null,
+    connectedLabel = '',
+    connectedUrl = '',
+    connectedBook = null,
+    tags = [],
+    formId = 'add',
+  } = opts;
   const prefix = `nf-${formId}`;
   const showConnect = noteType === 'connection';
+  const chipLabel = connectedBook
+    ? `${connectedBook.title} — ${connectedBook.author}`
+    : '';
+  const connectInputValue = chipLabel ? '' : connectedLabel;
+  const connectUrlValue = chipLabel ? '' : connectedUrl;
 
-  const connectedChipHtml = connectedBook
+  const connectedChipHtml = chipLabel
     ? `<div class="connect-chip" id="${prefix}-connect-chip">
-        <span>${escHtml(connectedBook.title)} — ${escHtml(connectedBook.author)}</span>
+        <span>${escHtml(chipLabel)}</span>
         <button type="button" data-clear-connect="${prefix}">&times;</button>
        </div>`
     : `<div class="connect-chip hidden" id="${prefix}-connect-chip"></div>`;
@@ -480,20 +534,25 @@ function buildNoteFormHtml(opts = {}) {
       <div class="note-form-row">
         <div>
           <label for="${prefix}-location">Page / Location</label>
-          <input type="text" id="${prefix}-location" placeholder="p.147, ch.3, etc." value="${escHtml(pageOrLocation || '')}">
+          <input type="text" id="${prefix}-location" placeholder="p.147, ch.3, etc." value="${escAttr(pageOrLocation || '')}">
         </div>
       </div>
       <div class="connect-field${showConnect ? '' : ' hidden'}" id="${prefix}-connect-wrap">
         <label for="${prefix}-connect-input">Connect to</label>
-        <input type="text" id="${prefix}-connect-input" placeholder="Search for a book..." autocomplete="off">
-        <input type="hidden" id="${prefix}-connect-id" value="${connectedId || ''}">
+        <input type="text" id="${prefix}-connect-input" placeholder="Search for a book or type another work..." autocomplete="off" value="${escAttr(connectInputValue || '')}">
+        <input type="hidden" id="${prefix}-connect-id" value="${escAttr(connectedId || '')}">
         <div class="connect-results hidden" id="${prefix}-connect-results"></div>
         ${connectedChipHtml}
+        <div class="connect-extra-field">
+          <label for="${prefix}-connect-url">External link</label>
+          <input type="url" id="${prefix}-connect-url" placeholder="https://example.com" value="${escAttr(connectUrlValue || '')}">
+          <div class="field-hint">Optional for articles, films, music, and other off-site references.</div>
+        </div>
       </div>
       <div>
         <button type="button" class="tags-toggle" id="${prefix}-tags-toggle">${tags.length ? 'Tags' : '+ Add tags'}</button>
         <div class="${tags.length ? '' : 'hidden'}" id="${prefix}-tags-wrap" style="margin-top:6px">
-          <input type="text" id="${prefix}-tags" placeholder="comma-separated, e.g. systems-thinking, emergence" value="${escHtml(tags.join(', '))}">
+          <input type="text" id="${prefix}-tags" placeholder="comma-separated, e.g. systems-thinking, emergence" value="${escAttr(tags.join(', '))}">
         </div>
       </div>
       <div class="form-error hidden" id="${prefix}-error"></div>
@@ -505,6 +564,15 @@ function getFormValues(prefix) {
   const content = document.getElementById(`${prefix}-content`).value.trim();
   const pageOrLocation = document.getElementById(`${prefix}-location`).value.trim() || null;
   const connectedId = document.getElementById(`${prefix}-connect-id`).value || null;
+  const connectTextInput = document.getElementById(`${prefix}-connect-input`);
+  const connectUrlInput = document.getElementById(`${prefix}-connect-url`);
+  const hasInternalConnection = noteType === 'connection' && !!connectedId;
+  const connectedLabel = noteType === 'connection' && !hasInternalConnection
+    ? (connectTextInput.value.trim() || null)
+    : null;
+  const connectedUrl = noteType === 'connection' && !hasInternalConnection
+    ? (connectUrlInput.value.trim() || null)
+    : null;
   const tagsRaw = document.getElementById(`${prefix}-tags`).value;
   const tags = tagsRaw ? tagsRaw.split(',').map(t => t.trim()).filter(Boolean) : null;
 
@@ -512,6 +580,8 @@ function getFormValues(prefix) {
     note_type: noteType,
     content,
     page_or_location: pageOrLocation,
+    connected_label: connectedLabel,
+    connected_url: connectedUrl,
     connected_source_id: connectedId ? Number(connectedId) : null,
     tags: tags && tags.length ? tags : null,
   };
@@ -551,11 +621,20 @@ function setupFormInteractions(prefix) {
   const contentEl = document.getElementById(`${prefix}-content`);
   const connectWrap = document.getElementById(`${prefix}-connect-wrap`);
   const connectInput = document.getElementById(`${prefix}-connect-input`);
+  const connectUrlEl = document.getElementById(`${prefix}-connect-url`);
   const connectResults = document.getElementById(`${prefix}-connect-results`);
   const connectIdEl = document.getElementById(`${prefix}-connect-id`);
   const connectChip = document.getElementById(`${prefix}-connect-chip`);
   const tagsToggle = document.getElementById(`${prefix}-tags-toggle`);
   const tagsWrap = document.getElementById(`${prefix}-tags-wrap`);
+
+  function syncConnectionMode() {
+    const hasInternalConnection = !!connectIdEl.value;
+    connectUrlEl.disabled = hasInternalConnection;
+    if (hasInternalConnection) {
+      connectUrlEl.value = '';
+    }
+  }
 
   // Type change → update placeholder + show/hide connect field
   typeSelect.addEventListener('change', () => {
@@ -565,6 +644,7 @@ function setupFormInteractions(prefix) {
     } else {
       connectWrap.classList.add('hidden');
     }
+    syncConnectionMode();
   });
 
   // Auto-grow textarea
@@ -586,6 +666,12 @@ function setupFormInteractions(prefix) {
   connectInput.addEventListener('input', () => {
     clearTimeout(searchTimeout);
     const q = connectInput.value.trim();
+    if (q) {
+      connectIdEl.value = '';
+      connectChip.innerHTML = '';
+      connectChip.classList.add('hidden');
+      syncConnectionMode();
+    }
     if (q.length < 2) { connectResults.classList.add('hidden'); return; }
     searchTimeout = setTimeout(() => {
       const matches = allBooks
@@ -594,7 +680,7 @@ function setupFormInteractions(prefix) {
         .slice(0, 8);
       if (!matches.length) { connectResults.classList.add('hidden'); return; }
       connectResults.innerHTML = matches.map(b =>
-        `<div class="connect-result" data-book-id="${b.id}" data-book-title="${escHtml(b.title)}" data-book-author="${escHtml(b.author)}">
+        `<div class="connect-result" data-book-id="${b.id}" data-book-title="${escAttr(b.title)}" data-book-author="${escAttr(b.author)}">
           <span>${escHtml(b.title)}</span>
           <span class="connect-result-author">${escHtml(b.author)}</span>
         </div>`
@@ -609,18 +695,22 @@ function setupFormInteractions(prefix) {
     const id = row.dataset.bookId;
     const title = row.dataset.bookTitle;
     const author = row.dataset.bookAuthor;
+    const chipLabel = `${title} — ${author}`;
     connectIdEl.value = id;
     connectInput.value = '';
     connectResults.classList.add('hidden');
-    connectChip.innerHTML = `<span>${escHtml(title)} — ${escHtml(author)}</span>
+    connectChip.innerHTML = `<span>${escHtml(chipLabel)}</span>
       <button type="button" data-clear-connect="${prefix}">&times;</button>`;
     connectChip.classList.remove('hidden');
+    syncConnectionMode();
   });
 
   // Close results on outside click
   document.addEventListener('click', (e) => {
     if (!connectWrap.contains(e.target)) connectResults.classList.add('hidden');
   });
+
+  syncConnectionMode();
 }
 
 // ── Event delegation ────────────────────────────────────────────────────────
@@ -631,6 +721,9 @@ document.addEventListener('click', async (e) => {
   if (clearBtn) {
     const prefix = clearBtn.dataset.clearConnect;
     document.getElementById(`${prefix}-connect-id`).value = '';
+    document.getElementById(`${prefix}-connect-input`).value = '';
+    const urlInput = document.getElementById(`${prefix}-connect-url`);
+    if (urlInput) urlInput.disabled = false;
     const chip = document.getElementById(`${prefix}-connect-chip`);
     chip.innerHTML = '';
     chip.classList.add('hidden');
@@ -683,6 +776,10 @@ async function handleAddNote() {
     showFormError(prefix, 'Note content cannot be empty.');
     return;
   }
+  if (values.note_type === 'connection' && !values.connected_source_id && !values.connected_label) {
+    showFormError(prefix, 'Choose a book or type what this note connects to.');
+    return;
+  }
 
   const btn = document.getElementById('add-note-btn');
   btn.disabled = true;
@@ -711,6 +808,10 @@ async function handleAddNote() {
     document.getElementById(`${prefix}-content`).value = '';
     document.getElementById(`${prefix}-location`).value = '';
     document.getElementById(`${prefix}-connect-id`).value = '';
+    document.getElementById(`${prefix}-connect-input`).value = '';
+    const connectUrl = document.getElementById(`${prefix}-connect-url`);
+    connectUrl.value = '';
+    connectUrl.disabled = false;
     document.getElementById(`${prefix}-tags`).value = '';
     const chip = document.getElementById(`${prefix}-connect-chip`);
     chip.innerHTML = '';
@@ -757,6 +858,8 @@ function handleEditStart(noteId) {
       content: note.content,
       pageOrLocation: note.page_or_location || '',
       connectedId: note.connected_source_id,
+      connectedLabel: note.connected_label || '',
+      connectedUrl: note.connected_url || '',
       connectedBook,
       tags: note.tags || [],
     })}
@@ -786,6 +889,10 @@ async function handleEditSave(noteId) {
 
   if (!values.content) {
     showFormError(prefix, 'Note content cannot be empty.');
+    return;
+  }
+  if (values.note_type === 'connection' && !values.connected_source_id && !values.connected_label) {
+    showFormError(prefix, 'Choose a book or type what this note connects to.');
     return;
   }
 

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -263,23 +263,43 @@ class DbSchemaTests(unittest.TestCase):
         self.assertIn("schema_version", tables)
         conn.close()
 
-    def test_schema_version_is_2(self):
+    def test_schema_version_is_4(self):
         conn = get_connection(self.db_path)
         run_migrations(conn)
-        self.assertEqual(get_schema_version(conn), 2)
+        self.assertEqual(get_schema_version(conn), 4)
         conn.close()
 
     def test_migrations_are_idempotent(self):
         conn = get_connection(self.db_path)
         run_migrations(conn)
         run_migrations(conn)
-        self.assertEqual(get_schema_version(conn), 2)
+        self.assertEqual(get_schema_version(conn), 4)
         conn.close()
 
     def test_existing_notes_table_upgrades_cleanly(self):
         conn = get_connection(self.db_path)
         db_module._migration_v1(conn)
-        conn.executescript(db_module._NOTES_SCHEMA)
+        conn.executescript("""
+            CREATE TABLE IF NOT EXISTS notes (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                source_type TEXT NOT NULL DEFAULT 'book'
+                    CHECK (source_type IN ('book', 'article', 'movie', 'blog', 'report', 'other')),
+                source_id INTEGER NOT NULL,
+                note_type TEXT NOT NULL DEFAULT 'thought'
+                    CHECK (note_type IN ('thought', 'quote', 'connection', 'disagreement', 'question')),
+                content TEXT NOT NULL,
+                page_or_location TEXT,
+                connected_source_type TEXT,
+                connected_source_id INTEGER,
+                tags TEXT,
+                created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+                updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+            );
+
+            CREATE INDEX IF NOT EXISTS idx_notes_source ON notes(source_type, source_id);
+            CREATE INDEX IF NOT EXISTS idx_notes_type ON notes(note_type);
+            CREATE INDEX IF NOT EXISTS idx_notes_connected ON notes(connected_source_type, connected_source_id);
+        """)
         conn.execute(
             """CREATE TABLE IF NOT EXISTS schema_version (
                 version INTEGER PRIMARY KEY,
@@ -297,10 +317,17 @@ class DbSchemaTests(unittest.TestCase):
             ).fetchall()
         }
 
-        self.assertEqual(applied, 1)
-        self.assertEqual(get_schema_version(conn), 2)
+        note_columns = {
+            row[1]
+            for row in conn.execute("PRAGMA table_info(notes)").fetchall()
+        }
+
+        self.assertEqual(applied, 3)
+        self.assertEqual(get_schema_version(conn), 4)
         self.assertIn("notes", tables)
         self.assertIn("activity_log", tables)
+        self.assertIn("connected_label", note_columns)
+        self.assertIn("connected_url", note_columns)
         conn.close()
 
     def test_insert_and_list_activity_rows(self):
@@ -896,6 +923,96 @@ class ApiSqliteTests(unittest.TestCase):
         self.assertEqual(activity[0]["event_type"], "note_added")
         self.assertEqual(activity[0]["note_type"], "quote")
         self.assertEqual(activity[0]["summary"], "Added a quote from Dune")
+
+    def test_create_connection_note_enriches_connected_book(self):
+        create = self.client.post(
+            "/api/books/1/notes",
+            json={
+                "note_type": "connection",
+                "content": "Echoes Orwell's warning.",
+                "connected_source_id": 2,
+            },
+            headers=TEST_AUTH_HEADER,
+        )
+
+        self.assertEqual(create.status_code, 201)
+        notes = self.client.get("/api/books/1/notes").json()["notes"]
+        self.assertEqual(notes[0]["note_type"], "connection")
+        self.assertEqual(notes[0]["connected_source_id"], 2)
+        self.assertIsNone(notes[0]["connected_label"])
+        self.assertIsNone(notes[0]["connected_url"])
+        self.assertEqual(notes[0]["connected_book"]["title"], "1984")
+
+    def test_connection_note_accepts_external_label_without_book_id(self):
+        create = self.client.post(
+            "/api/books/1/notes",
+            json={
+                "note_type": "connection",
+                "content": "The same dread as a Bergman film.",
+                "connected_label": "Winter Light",
+            },
+            headers=TEST_AUTH_HEADER,
+        )
+
+        self.assertEqual(create.status_code, 201)
+        notes = self.client.get("/api/books/1/notes").json()["notes"]
+        self.assertEqual(notes[0]["note_type"], "connection")
+        self.assertIsNone(notes[0]["connected_source_id"])
+        self.assertEqual(notes[0]["connected_label"], "Winter Light")
+        self.assertIsNone(notes[0]["connected_url"])
+        self.assertIsNone(notes[0]["connected_book"])
+
+    def test_connection_note_accepts_external_url(self):
+        create = self.client.post(
+            "/api/books/1/notes",
+            json={
+                "note_type": "connection",
+                "content": "This has the same stripped spiritual chill.",
+                "connected_label": "Winter Light",
+                "connected_url": "https://en.wikipedia.org/wiki/Winter_Light",
+            },
+            headers=TEST_AUTH_HEADER,
+        )
+
+        self.assertEqual(create.status_code, 201)
+        notes = self.client.get("/api/books/1/notes").json()["notes"]
+        self.assertEqual(notes[0]["connected_label"], "Winter Light")
+        self.assertEqual(
+            notes[0]["connected_url"],
+            "https://en.wikipedia.org/wiki/Winter_Light",
+        )
+        self.assertIsNone(notes[0]["connected_book"])
+
+    def test_connection_note_requires_connected_book_or_label(self):
+        missing = self.client.post(
+            "/api/books/1/notes",
+            json={"note_type": "connection", "content": "Missing target."},
+            headers=TEST_AUTH_HEADER,
+        )
+        invalid = self.client.post(
+            "/api/books/1/notes",
+            json={
+                "note_type": "connection",
+                "content": "Bad target.",
+                "connected_source_id": 99999,
+            },
+            headers=TEST_AUTH_HEADER,
+        )
+        invalid_url = self.client.post(
+            "/api/books/1/notes",
+            json={
+                "note_type": "connection",
+                "content": "Bad URL.",
+                "connected_label": "Winter Light",
+                "connected_url": "winter-light",
+            },
+            headers=TEST_AUTH_HEADER,
+        )
+
+        self.assertEqual(missing.status_code, 422)
+        self.assertEqual(invalid.status_code, 422)
+        self.assertEqual(invalid_url.status_code, 422)
+        self.assertEqual(self.client.get("/api/books/1/notes").json()["notes"], [])
 
     def test_notes_endpoint_returns_newest_first(self):
         first = self.client.post(


### PR DESCRIPTION
## Summary
- replace the white external connection card with a quieter reference treatment on the book page
- support external connection URLs alongside free-text labels while keeping internal book connections first-class
- add the schema migration and regression coverage for internal, external, and linked connection notes

## Why
External references like films, essays, or music should not look like fake in-site cards. They need a cleaner visual treatment and an optional outbound link, while internal bookshelf links should remain structured and clickable.

## Validation
- `./.venv/bin/python -m unittest tests.test_db.DbSchemaTests.test_schema_version_is_4 tests.test_db.DbSchemaTests.test_migrations_are_idempotent tests.test_db.DbSchemaTests.test_existing_notes_table_upgrades_cleanly tests.test_db.ApiSqliteTests.test_create_connection_note_enriches_connected_book tests.test_db.ApiSqliteTests.test_connection_note_accepts_external_label_without_book_id tests.test_db.ApiSqliteTests.test_connection_note_accepts_external_url tests.test_db.ApiSqliteTests.test_connection_note_requires_connected_book_or_label tests.test_db.ApiSqliteTests.test_notes_endpoint_returns_newest_first tests.test_db.ApiSqliteTests.test_create_note_logs_note_added tests.test_db.ApiSqliteTests.test_note_update_and_delete_do_not_log_activity`
- deployed and verified on staging and production before publishing

Closes #21
