### PR TITLE
Add capture_events table for mobile capture flow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ FORCE_LLM ?= 0
 .PHONY: install parse llm llm-force llm-staging llm-staging-force build refresh-data dev \
         deploy deploy-sync restart-api backup pull-db push-db \
         deploy-staging deploy-staging-sync restart-staging-api seed-staging \
-        add-notes-table
+        add-notes-table add-capture-table
 
 install:
 	$(PYTHON) -m venv $(VENV_DIR)
@@ -142,3 +142,6 @@ seed-staging:
 
 add-notes-table:
 	$(RUN_PYTHON) scripts/add_notes_table.py
+
+add-capture-table:
+	$(RUN_PYTHON) scripts/add_capture_table.py

--- a/scripts/add_capture_table.py
+++ b/scripts/add_capture_table.py
@@ -1,0 +1,58 @@
+"""
+Migration script: add the `capture_events` table to the bookshelf database.
+
+Idempotent — safe to run multiple times.
+"""
+
+import os
+import sqlite3
+import sys
+from pathlib import Path
+
+DB_PATH = os.environ.get("DB_PATH", "data/bookshelf.db")
+
+SCHEMA = """
+CREATE TABLE IF NOT EXISTS capture_events (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    raw_text TEXT NOT NULL,
+    source_channel TEXT NOT NULL DEFAULT 'telegram',
+    status TEXT NOT NULL DEFAULT 'pending'
+        CHECK (status IN ('pending', 'applied', 'discarded')),
+    resolved_book_id INTEGER,
+    resolved_note_type TEXT,
+    resolved_content TEXT,
+    resolved_page_or_location TEXT,
+    resolved_tags TEXT,
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+    resolved_at TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_capture_status ON capture_events(status);
+CREATE INDEX IF NOT EXISTS idx_capture_created ON capture_events(created_at);
+"""
+
+
+def main() -> None:
+    db_path = Path(DB_PATH)
+    if not db_path.exists():
+        print(f"Error: database not found at {db_path}", file=sys.stderr)
+        sys.exit(1)
+
+    conn = sqlite3.connect(str(db_path))
+    try:
+        # Check if table already exists
+        row = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='capture_events'"
+        ).fetchone()
+
+        if row:
+            print("capture_events table already exists")
+        else:
+            conn.executescript(SCHEMA)
+            print("capture_events table created")
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Adds the `capture_events` holding table that will back the mobile capture → desktop triage flow
- New `scripts/add_capture_table.py` migration (idempotent, matches the pattern of `add_notes_table.py`)
- New `make add-capture-table` target

Implements Task 1 of the mobile-capture spec. Later tasks (Telegram bot, API endpoints, inbox UI) will land in follow-up PRs.

Refs #28

## Test plan
- [x] `make add-capture-table` → prints `capture_events table created`
- [x] `.tables` shows `capture_events` alongside the existing tables
- [x] `.schema capture_events` matches the spec (columns, CHECK, both indexes)
- [x] Re-running the migration prints `capture_events table already exists` with no error
- [x] Inserting a row with `status='bogus'` fails the CHECK constraint
- [x] Inserting with defaults yields `source_channel='telegram'`, `status='pending'`, and a UTC `created_at`

🤖 Generated with [Claude Code](https://claude.com/claude-code)