### PR TITLE
Add Telegram capture bot

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,10 @@ BOOKS_DATA=data/books.json
 LLM_CACHE_DATA=data/llm_cache.json
 BOOKSHELF_CORS_ORIGINS=https://book.tanxy.net,https://dev.book.tanxy.net,http://localhost:8000,http://127.0.0.1:8000
 
+# Telegram capture bot (see api/telegram_bot.py)
+TELEGRAM_BOT_TOKEN=
+TELEGRAM_ALLOWED_CHAT_ID=
+
 # Optional suggestion email delivery
 BOOK_SUGGESTIONS_TO_EMAIL=suggest.book@tanxy.net
 BOOK_SUGGESTION_IP_SALT=

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ RUN_PYTHON := $(if $(wildcard $(VENV_PY)),$(VENV_PY),$(PYTHON))
 VPS_HOST  ?= root@134.199.239.64
 VPS_PATH  ?= /var/www/book.tanxy.net
 VPS_SERVICE ?= bookshelf-api
+VPS_BOT_SERVICE ?= bookshelf-telegram-bot
 STAGING_VPS_HOST ?= $(VPS_HOST)
 STAGING_VPS_PATH ?= /var/www/dev.book.tanxy.net
 STAGING_DOMAIN ?= dev.book.tanxy.net
@@ -16,9 +17,10 @@ STAGING_OPENAI_MODEL ?= gpt-4.1-nano
 FORCE_LLM ?= 0
 
 .PHONY: install parse llm llm-force llm-staging llm-staging-force build refresh-data dev \
-        deploy deploy-sync restart-api backup pull-db push-db \
+        deploy deploy-sync restart-api restart-bot backup pull-db push-db \
         deploy-staging deploy-staging-sync restart-staging-api seed-staging \
-        add-notes-table add-capture-table
+        add-notes-table add-capture-table \
+        bot-status bot-logs bot-restart
 
 install:
 	$(PYTHON) -m venv $(VENV_DIR)
@@ -76,7 +78,7 @@ dev:
 
 # ── Production deploy ────────────────────────────────────────────────────────
 
-deploy: backup deploy-sync restart-api
+deploy: backup deploy-sync restart-api restart-bot
 	@echo "Production deploy complete for $(VPS_HOST):$(VPS_PATH)"
 
 deploy-sync:
@@ -86,12 +88,16 @@ deploy-sync:
 	rsync -avz api/ $(VPS_HOST):$(VPS_PATH)/api/
 	rsync -avz scripts/ $(VPS_HOST):$(VPS_PATH)/scripts/
 	rsync -avz bookshelf_data.py db.py $(VPS_HOST):$(VPS_PATH)/
-	rsync -avz deploy/nginx.conf deploy/bookshelf.service $(VPS_HOST):$(VPS_PATH)/deploy/
+	rsync -avz deploy/nginx.conf deploy/bookshelf.service deploy/telegram-bot.service $(VPS_HOST):$(VPS_PATH)/deploy/
 	rsync -avz .env.example README.md Makefile $(VPS_HOST):$(VPS_PATH)/
 
 restart-api:
 	@echo "Restarting production service $(VPS_SERVICE)"
 	ssh $(VPS_HOST) "systemctl restart $(VPS_SERVICE) && systemctl is-active $(VPS_SERVICE)"
+
+restart-bot:
+	@echo "Restarting telegram bot service $(VPS_BOT_SERVICE) (if installed)"
+	@ssh $(VPS_HOST) 'if systemctl list-unit-files | grep -q "^$(VPS_BOT_SERVICE).service"; then systemctl restart $(VPS_BOT_SERVICE) && systemctl is-active $(VPS_BOT_SERVICE); else echo "$(VPS_BOT_SERVICE) not installed — skipping"; fi'
 
 backup:
 	@echo "Backing up production database…"
@@ -145,3 +151,14 @@ add-notes-table:
 
 add-capture-table:
 	$(RUN_PYTHON) scripts/add_capture_table.py
+
+# ── Telegram capture bot ────────────────────────────────────────────────────
+
+bot-status:
+	ssh $(VPS_HOST) "systemctl status $(VPS_BOT_SERVICE)"
+
+bot-logs:
+	ssh $(VPS_HOST) "journalctl -u $(VPS_BOT_SERVICE) -f"
+
+bot-restart:
+	ssh $(VPS_HOST) "systemctl restart $(VPS_BOT_SERVICE) && systemctl is-active $(VPS_BOT_SERVICE)"

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -1,3 +1,4 @@
 fastapi==0.111.0
 uvicorn[standard]==0.29.0
 httpx==0.27.0
+python-telegram-bot>=21.0

--- a/api/telegram_bot.py
+++ b/api/telegram_bot.py
@@ -1,0 +1,228 @@
+"""
+Telegram capture bot for book.tanxy.net.
+
+Runs as a separate long-lived process alongside the FastAPI server.
+Listens for text messages from an allow-listed chat and writes each
+message verbatim into the `capture_events` table for later triage
+from the desktop inbox UI.
+
+Environment variables (loaded from `.env` at repo root):
+    TELEGRAM_BOT_TOKEN        Bot token from @BotFather (required)
+    TELEGRAM_ALLOWED_CHAT_ID  Numeric chat ID of the only sender allowed
+                              to store captures (required)
+    DB_PATH                   Path to the SQLite database
+                              (default: data/bookshelf.db)
+
+Run locally:
+    .venv/bin/python -m api.telegram_bot
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sqlite3
+import sys
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT_DIR))
+
+from bookshelf_data import load_env_file  # noqa: E402
+
+try:
+    from telegram import Update
+    from telegram.ext import (
+        Application,
+        CommandHandler,
+        ContextTypes,
+        MessageHandler,
+        filters,
+    )
+except ImportError:  # pragma: no cover — import guard
+    print(
+        "Error: python-telegram-bot is not installed. "
+        "Install with: pip install 'python-telegram-bot>=21.0'",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+
+load_env_file(ROOT_DIR / ".env")
+
+logging.basicConfig(
+    format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+    level=logging.INFO,
+)
+# Quiet the noisy underlying HTTP client; keep our own logger at INFO.
+logging.getLogger("httpx").setLevel(logging.WARNING)
+logger = logging.getLogger("bookshelf.telegram_bot")
+
+
+TOKEN = os.getenv("TELEGRAM_BOT_TOKEN", "").strip()
+ALLOWED_CHAT_ID_RAW = os.getenv("TELEGRAM_ALLOWED_CHAT_ID", "").strip()
+DB_PATH = os.getenv("DB_PATH", "").strip() or "data/bookshelf.db"
+
+RECENT_LIMIT = 5
+RAW_TEXT_PREVIEW_LIMIT = 50
+
+
+def _die(message: str) -> "NoReturn":  # type: ignore[name-defined]
+    print(f"Error: {message}", file=sys.stderr)
+    sys.exit(1)
+
+
+if not TOKEN:
+    _die("TELEGRAM_BOT_TOKEN is not set")
+if not ALLOWED_CHAT_ID_RAW:
+    _die("TELEGRAM_ALLOWED_CHAT_ID is not set")
+
+try:
+    ALLOWED_CHAT_ID = int(ALLOWED_CHAT_ID_RAW)
+except ValueError:
+    _die(
+        "TELEGRAM_ALLOWED_CHAT_ID must be an integer, "
+        f"got: {ALLOWED_CHAT_ID_RAW!r}"
+    )
+
+
+# ── Database helpers ─────────────────────────────────────────────────────────
+
+
+def _db_connect() -> sqlite3.Connection:
+    conn = sqlite3.connect(DB_PATH)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def insert_capture(raw_text: str) -> int:
+    """Store a raw Telegram message as a pending capture event. Returns new id."""
+    conn = _db_connect()
+    try:
+        cursor = conn.execute(
+            "INSERT INTO capture_events (raw_text, source_channel) VALUES (?, 'telegram')",
+            (raw_text,),
+        )
+        conn.commit()
+        return int(cursor.lastrowid)
+    finally:
+        conn.close()
+
+
+def fetch_recent_captures(limit: int = RECENT_LIMIT) -> list[sqlite3.Row]:
+    conn = _db_connect()
+    try:
+        return conn.execute(
+            "SELECT id, status, raw_text FROM capture_events "
+            "ORDER BY created_at DESC LIMIT ?",
+            (limit,),
+        ).fetchall()
+    finally:
+        conn.close()
+
+
+def _truncate(text: str, limit: int = RAW_TEXT_PREVIEW_LIMIT) -> str:
+    text = text.replace("\n", " ").strip()
+    if len(text) <= limit:
+        return text
+    return text[:limit] + "..."
+
+
+# ── Handlers ─────────────────────────────────────────────────────────────────
+
+
+async def handle_start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Reply with the caller's chat id. Intentionally not auth-gated — this
+    is how the user discovers their own chat id during initial setup."""
+    chat = update.effective_chat
+    if chat is None:
+        return
+    await context.bot.send_message(
+        chat_id=chat.id, text=f"Your chat ID is: {chat.id}"
+    )
+
+
+async def handle_recent(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    chat = update.effective_chat
+    if chat is None:
+        return
+    if chat.id != ALLOWED_CHAT_ID:
+        await context.bot.send_message(chat_id=chat.id, text="Unauthorized")
+        logger.warning("rejected /recent from unauthorized chat_id=%s", chat.id)
+        return
+
+    try:
+        rows = fetch_recent_captures()
+    except sqlite3.Error:
+        logger.exception("failed to fetch recent captures")
+        await context.bot.send_message(
+            chat_id=chat.id, text="Failed to fetch recent captures."
+        )
+        return
+
+    if not rows:
+        await context.bot.send_message(chat_id=chat.id, text="No captures yet.")
+        return
+
+    lines = ["Recent captures:"]
+    for row in rows:
+        preview = _truncate(row["raw_text"] or "")
+        lines.append(f'#{row["id"]} ({row["status"]}) — "{preview}"')
+    await context.bot.send_message(chat_id=chat.id, text="\n".join(lines))
+
+
+async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    chat = update.effective_chat
+    message = update.effective_message
+    if chat is None or message is None:
+        return
+
+    if chat.id != ALLOWED_CHAT_ID:
+        await context.bot.send_message(chat_id=chat.id, text="Unauthorized")
+        logger.warning("rejected message from unauthorized chat_id=%s", chat.id)
+        return
+
+    raw_text = (message.text or "").strip()
+    if not raw_text:
+        return
+
+    try:
+        capture_id = insert_capture(raw_text)
+    except sqlite3.Error:
+        logger.exception("failed to insert capture")
+        await context.bot.send_message(
+            chat_id=chat.id, text="Failed to store capture."
+        )
+        return
+
+    logger.info("stored capture #%s (%d chars)", capture_id, len(raw_text))
+    await context.bot.send_message(
+        chat_id=chat.id, text=f"✓ Captured (#{capture_id})"
+    )
+
+
+# ── Entrypoint ───────────────────────────────────────────────────────────────
+
+
+def build_application() -> Application:
+    application = Application.builder().token(TOKEN).build()
+    application.add_handler(CommandHandler("start", handle_start))
+    application.add_handler(CommandHandler("recent", handle_recent))
+    application.add_handler(
+        MessageHandler(filters.TEXT & ~filters.COMMAND, handle_message)
+    )
+    return application
+
+
+def main() -> None:
+    logger.info(
+        "starting telegram bot (allowed_chat_id=%s, db_path=%s)",
+        ALLOWED_CHAT_ID,
+        DB_PATH,
+    )
+    application = build_application()
+    application.run_polling(allowed_updates=Update.ALL_TYPES)
+
+
+if __name__ == "__main__":
+    main()

--- a/deploy/telegram-bot.service
+++ b/deploy/telegram-bot.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Bookshelf Telegram Capture Bot
+After=network.target
+
+[Service]
+Type=simple
+User=www-data
+Group=www-data
+WorkingDirectory=/var/www/book.tanxy.net
+EnvironmentFile=/etc/bookshelf.env
+ExecStart=/var/www/book.tanxy.net/.venv/bin/python -m api.telegram_bot
+Restart=always
+RestartSec=10
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
- New `api/telegram_bot.py` long-lived bot process that stores text messages from an allow-listed Telegram chat into the `capture_events` table as `pending` rows
- `/start` (chat-id discovery, not auth-gated) and `/recent` (last 5 captures, auth-gated) helper commands
- `deploy/telegram-bot.service` systemd unit, plus `make bot-status` / `make bot-logs` / `make bot-restart` helpers
- `make deploy` now also restarts the bot service (no-ops when the unit isn't installed yet, so first deploy is safe)
- `python-telegram-bot>=21.0` added to `api/requirements.txt`; `TELEGRAM_BOT_TOKEN` / `TELEGRAM_ALLOWED_CHAT_ID` documented in `.env.example`

Implements Task 2 of the mobile-capture spec. Task 1 landed in #35; Tasks 3–5 (API endpoints, inbox UI, VPS deploy) will come in follow-up PRs.

Refs #28

## Notes on spec deviations
- Spec says \`server/telegram_bot.py\` but this repo keeps runtime code in \`api/\`, so the module is \`api.telegram_bot\` and the systemd \`ExecStart\` matches.
- Systemd \`WorkingDirectory\` and \`EnvironmentFile\` adjusted to match the existing \`bookshelf.service\` (\`/var/www/book.tanxy.net\` and \`/etc/bookshelf.env\`).

## Test plan
- [x] Offline: \`build_application()\` registers 3 handlers (/start, /recent, message)
- [x] Offline: \`insert_capture\` / \`fetch_recent_captures\` round-trip against a temp DB
- [x] Offline: \`_truncate\` correct at boundaries (len ≤ 50 unchanged, 51 truncated)
- [x] Offline: missing \`TELEGRAM_BOT_TOKEN\` exits with clear error
- [x] Live: \`.venv/bin/python -m api.telegram_bot\` starts and connects
- [x] Live: \`/start\` from any account replies with that account's chat id
- [x] Live: text messages from the allowed chat get \`✓ Captured (#N)\` and land in \`capture_events\` with \`status='pending'\`, \`source_channel='telegram'\`
- [x] Live: \`/recent\` lists the last 5 captures with truncated previews
- [x] Live: messages from a non-allowed chat id get \`Unauthorized\` and do not create rows (verified via bot log \`rejected message from unauthorized chat_id=...\`)
- [ ] VPS systemd unit install + \`make bot-status\` (deferred to Task 5 deploy PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)