### PR TITLE
[codex] Collapse repetitive note bursts in homepage activity preview

### DIFF
--- a/api/activity.py
+++ b/api/activity.py
@@ -2,13 +2,18 @@
 
 from __future__ import annotations
 
+from datetime import datetime
 from typing import Any
+from zoneinfo import ZoneInfo
 
 from fastapi import APIRouter, Query
 
 from db import list_activity_rows
 
 router = APIRouter(prefix="/api/activity")
+
+_PREVIEW_TIMEZONE = ZoneInfo("America/Los_Angeles")
+_PREVIEW_FETCH_BATCH = 200
 
 
 def _get_deps() -> tuple:
@@ -37,12 +42,17 @@ def _summary_for_row(row: dict[str, Any]) -> str:
     return f"Added a note on {title}"
 
 
-def _serialize_row(row: dict[str, Any]) -> dict[str, Any]:
+def _serialize_row(
+    row: dict[str, Any],
+    *,
+    summary: str | None = None,
+    include_note_type: bool = True,
+) -> dict[str, Any]:
     payload = {
         "id": row["id"],
         "event_type": row["event_type"],
         "created_at": row["created_at"],
-        "summary": _summary_for_row(row),
+        "summary": summary or _summary_for_row(row),
         "book": {
             "id": row["book_id"],
             "title": row["book_title"],
@@ -50,9 +60,77 @@ def _serialize_row(row: dict[str, Any]) -> dict[str, Any]:
             "href": _book_href(row["book_id"], bool(row["book_exists"])),
         },
     }
-    if row.get("note_type"):
+    if include_note_type and row.get("note_type"):
         payload["note_type"] = row["note_type"]
     return payload
+
+
+def _list_all_activity_rows(conn) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    offset = 0
+
+    while True:
+        batch = list_activity_rows(conn, limit=_PREVIEW_FETCH_BATCH, offset=offset)
+        rows.extend(batch)
+        if len(batch) < _PREVIEW_FETCH_BATCH:
+            break
+        offset += _PREVIEW_FETCH_BATCH
+
+    return rows
+
+
+def _note_preview_group_key(row: dict[str, Any]) -> tuple[int, str] | None:
+    if row.get("event_type") != "note_added":
+        return None
+
+    created_at = row.get("created_at")
+    if not created_at:
+        return None
+
+    try:
+        timestamp = datetime.fromisoformat(str(created_at).replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+    local_day = timestamp.astimezone(_PREVIEW_TIMEZONE).date().isoformat()
+    return row["book_id"], local_day
+
+
+def _serialize_preview_rows(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    preview_entries: list[dict[str, Any]] = []
+    note_group_indexes: dict[tuple[int, str], int] = {}
+
+    for row in rows:
+        group_key = _note_preview_group_key(row)
+        if group_key is None:
+            preview_entries.append({"row": row, "count": 1})
+            continue
+
+        existing_index = note_group_indexes.get(group_key)
+        if existing_index is None:
+            note_group_indexes[group_key] = len(preview_entries)
+            preview_entries.append({"row": row, "count": 1})
+            continue
+
+        preview_entries[existing_index]["count"] += 1
+
+    items: list[dict[str, Any]] = []
+    for entry in preview_entries:
+        row = entry["row"]
+        count = entry["count"]
+        if count > 1:
+            title = row.get("book_title") or "Untitled"
+            items.append(
+                _serialize_row(
+                    row,
+                    summary=f"Added {count} notes on {title}",
+                    include_note_type=False,
+                )
+            )
+            continue
+        items.append(_serialize_row(row))
+
+    return items
 
 
 def _empty_response(limit: int, offset: int) -> dict[str, Any]:
@@ -71,17 +149,26 @@ def _empty_response(limit: int, offset: int) -> dict[str, Any]:
 async def get_activity(
     limit: int = Query(default=30, ge=1, le=100),
     offset: int = Query(default=0, ge=0),
+    view: str | None = Query(default=None),
 ) -> dict[str, Any]:
     store, USE_SQLITE = _get_deps()
     if not USE_SQLITE:
         return _empty_response(limit, offset)
 
-    rows = list_activity_rows(store.conn(), limit=limit + 1, offset=offset)
-    has_more = len(rows) > limit
-    visible_rows = rows[:limit]
+    conn = store.conn()
+    requested_view = (view or "").strip().lower()
+
+    if requested_view == "preview":
+        items = _serialize_preview_rows(_list_all_activity_rows(conn))
+        has_more = len(items) > offset + limit
+        visible_items = items[offset:offset + limit]
+    else:
+        rows = list_activity_rows(conn, limit=limit + 1, offset=offset)
+        has_more = len(rows) > limit
+        visible_items = [_serialize_row(row) for row in rows[:limit]]
 
     return {
-        "items": [_serialize_row(row) for row in visible_rows],
+        "items": visible_items,
         "pagination": {
             "limit": limit,
             "offset": offset,

--- a/site/index.html
+++ b/site/index.html
@@ -3099,7 +3099,7 @@ async function load() {
     fetchJson('/api/taste-profile'),
     fetchJson('/api/recommendations'),
     fetchJson('/api/health'),
-    fetchJson('/api/activity?limit=3'),
+    fetchJson('/api/activity?view=preview&limit=3'),
   ]);
 
   if (booksResult.status !== 'fulfilled') {

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -703,6 +703,24 @@ class ApiSqliteTests(unittest.TestCase):
         os.environ.update(self.original_env)
         self.tempdir.cleanup()
 
+    def _set_activity_created_at(self, activity_id: int, created_at: str) -> None:
+        conn = get_connection(self.db_path)
+        conn.execute(
+            "UPDATE activity_log SET created_at = ? WHERE id = ?",
+            (created_at, activity_id),
+        )
+        conn.commit()
+        conn.close()
+
+    def _set_note_activity_created_at(self, note_id: int, created_at: str) -> None:
+        conn = get_connection(self.db_path)
+        conn.execute(
+            "UPDATE activity_log SET created_at = ? WHERE event_type = 'note_added' AND note_id = ?",
+            (created_at, note_id),
+        )
+        conn.commit()
+        conn.close()
+
     def test_books_endpoint(self):
         resp = self.client.get("/api/books")
         self.assertEqual(resp.status_code, 200)
@@ -1002,6 +1020,177 @@ class ApiSqliteTests(unittest.TestCase):
         self.assertEqual(activity[0]["event_type"], "note_added")
         self.assertEqual(activity[0]["note_type"], "quote")
         self.assertEqual(activity[0]["summary"], "Added a quote from Dune")
+
+    def test_activity_preview_collapses_same_day_notes_per_book(self):
+        for content in ("First note.", "Second note.", "Third note."):
+            resp = self.client.post(
+                "/api/books/1/notes",
+                json={"note_type": "thought", "content": content},
+                headers=TEST_AUTH_HEADER,
+            )
+            self.assertEqual(resp.status_code, 201)
+
+        raw = self.client.get("/api/activity?limit=10").json()["items"]
+        preview = self.client.get("/api/activity?view=preview&limit=10").json()["items"]
+
+        self.assertEqual(len(raw), 3)
+        self.assertEqual(len(preview), 1)
+        self.assertEqual(preview[0]["event_type"], "note_added")
+        self.assertEqual(preview[0]["summary"], "Added 3 notes on Dune")
+        self.assertEqual(preview[0]["created_at"], raw[0]["created_at"])
+        self.assertNotIn("note_type", preview[0])
+
+    def test_activity_preview_does_not_collapse_notes_across_pacific_days(self):
+        first = self.client.post(
+            "/api/books/1/notes",
+            json={"note_type": "thought", "content": "Late-night note."},
+            headers=TEST_AUTH_HEADER,
+        )
+        second = self.client.post(
+            "/api/books/1/notes",
+            json={"note_type": "thought", "content": "Early-morning note."},
+            headers=TEST_AUTH_HEADER,
+        )
+
+        self.assertEqual(first.status_code, 201)
+        self.assertEqual(second.status_code, 201)
+
+        self._set_note_activity_created_at(first.json()["id"], "2026-04-05T06:30:00Z")
+        self._set_note_activity_created_at(second.json()["id"], "2026-04-05T08:30:00Z")
+
+        preview = self.client.get("/api/activity?view=preview&limit=10").json()["items"]
+
+        self.assertEqual(len(preview), 2)
+        self.assertEqual(
+            [item["summary"] for item in preview],
+            ["Added a note on Dune", "Added a note on Dune"],
+        )
+
+    def test_activity_preview_does_not_collapse_notes_for_different_books(self):
+        first = self.client.post(
+            "/api/books/1/notes",
+            json={"note_type": "thought", "content": "Dune note."},
+            headers=TEST_AUTH_HEADER,
+        )
+        second = self.client.post(
+            "/api/books/2/notes",
+            json={"note_type": "thought", "content": "1984 note."},
+            headers=TEST_AUTH_HEADER,
+        )
+
+        self.assertEqual(first.status_code, 201)
+        self.assertEqual(second.status_code, 201)
+
+        preview = self.client.get("/api/activity?view=preview&limit=10").json()["items"]
+
+        self.assertEqual(len(preview), 2)
+        self.assertEqual(
+            {item["summary"] for item in preview},
+            {"Added a note on Dune", "Added a note on 1984"},
+        )
+
+    def test_activity_preview_does_not_collapse_notes_with_other_event_types(self):
+        first = self.client.post(
+            "/api/books/1/notes",
+            json={"note_type": "thought", "content": "First note."},
+            headers=TEST_AUTH_HEADER,
+        )
+        second = self.client.post(
+            "/api/books/1/notes",
+            json={"note_type": "quote", "content": "Second note."},
+            headers=TEST_AUTH_HEADER,
+        )
+
+        self.assertEqual(first.status_code, 201)
+        self.assertEqual(second.status_code, 201)
+
+        conn = get_connection(self.db_path)
+        activity_id = db_module.insert_activity(
+            conn,
+            event_type="started_reading",
+            book_id=1,
+            book_title="Dune",
+            book_author="Frank Herbert",
+        )
+        conn.commit()
+        conn.close()
+
+        self._set_note_activity_created_at(first.json()["id"], "2026-04-05T16:00:00Z")
+        self._set_note_activity_created_at(second.json()["id"], "2026-04-05T17:00:00Z")
+        self._set_activity_created_at(activity_id, "2026-04-05T16:30:00Z")
+
+        preview = self.client.get("/api/activity?view=preview&limit=10").json()["items"]
+
+        self.assertEqual(
+            [item["summary"] for item in preview],
+            ["Added 2 notes on Dune", "Started Dune"],
+        )
+
+    def test_activity_preview_paginates_after_grouping(self):
+        dune_first = self.client.post(
+            "/api/books/1/notes",
+            json={"note_type": "thought", "content": "Dune first."},
+            headers=TEST_AUTH_HEADER,
+        )
+        dune_second = self.client.post(
+            "/api/books/1/notes",
+            json={"note_type": "thought", "content": "Dune second."},
+            headers=TEST_AUTH_HEADER,
+        )
+        nineteen_eighty_four = self.client.post(
+            "/api/books/2/notes",
+            json={"note_type": "thought", "content": "1984 note."},
+            headers=TEST_AUTH_HEADER,
+        )
+        no_date_book = self.client.post(
+            "/api/books/3/notes",
+            json={"note_type": "thought", "content": "No Date Book note."},
+            headers=TEST_AUTH_HEADER,
+        )
+        create = self.client.post(
+            "/api/books",
+            json={"title": "Preview Fourth", "author": "Author", "exclusive_shelf": "to_read"},
+            headers=TEST_AUTH_HEADER,
+        )
+
+        self.assertEqual(dune_first.status_code, 201)
+        self.assertEqual(dune_second.status_code, 201)
+        self.assertEqual(nineteen_eighty_four.status_code, 201)
+        self.assertEqual(no_date_book.status_code, 201)
+        self.assertEqual(create.status_code, 201)
+
+        self._set_note_activity_created_at(dune_first.json()["id"], "2026-04-05T17:00:00Z")
+        self._set_note_activity_created_at(dune_second.json()["id"], "2026-04-05T16:00:00Z")
+        self._set_note_activity_created_at(nineteen_eighty_four.json()["id"], "2026-04-05T15:00:00Z")
+        self._set_note_activity_created_at(no_date_book.json()["id"], "2026-04-05T14:00:00Z")
+
+        raw = self.client.get("/api/activity?limit=10").json()["items"]
+        preview_fourth_id = next(
+            item["id"] for item in raw if item["summary"] == "Added Preview Fourth to to-read"
+        )
+        self._set_activity_created_at(preview_fourth_id, "2026-04-05T13:00:00Z")
+
+        first_page = self.client.get("/api/activity?view=preview&limit=3&offset=0").json()
+        second_page = self.client.get("/api/activity?view=preview&limit=3&offset=3").json()
+
+        self.assertEqual(len(first_page["items"]), 3)
+        self.assertTrue(first_page["pagination"]["has_more"])
+        self.assertEqual(first_page["pagination"]["next_offset"], 3)
+        self.assertEqual(
+            [item["summary"] for item in first_page["items"]],
+            [
+                "Added 2 notes on Dune",
+                "Added a note on 1984",
+                "Added a note on No Date Book",
+            ],
+        )
+        self.assertEqual(len(second_page["items"]), 1)
+        self.assertFalse(second_page["pagination"]["has_more"])
+        self.assertEqual(second_page["items"][0]["summary"], "Added Preview Fourth to to-read")
+
+    def test_homepage_activity_preview_requests_preview_view(self):
+        homepage = (ROOT / "site/index.html").read_text(encoding="utf-8")
+        self.assertIn("fetchJson('/api/activity?view=preview&limit=3')", homepage)
 
     def test_create_connection_note_enriches_connected_book(self):
         create = self.client.post(


### PR DESCRIPTION
## Summary
- add a preview-only `view=preview` mode to `/api/activity`
- collapse same-day `note_added` events for the same book in Pacific time while keeping the raw activity log unchanged
- update the homepage preview to use the collapsed view and add regression coverage for grouping and pagination

## Why
The homepage activity band can look quieter than it really is when multiple notes are added to the same book on the same day. Grouping those bursts into a single summary makes the preview feel less repetitive without losing the detailed archive on `/log`.

Closes #39

## Validation
- `/Users/xinyutan/Documents/projects/bookshelf/.venv/bin/python -m unittest tests.test_db.ApiSqliteTests`
- `/Users/xinyutan/Documents/projects/bookshelf/.venv/bin/python -m unittest tests.test_api`
- local manual check on the branch build via the homepage preview and raw activity endpoints
