### PR TITLE
Document mobile capture deployment (Task 5)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,14 +12,24 @@ make llm-force       # Always regenerate LLM outputs (legacy)
 make build           # parse + llm (legacy pipeline)
 make dev             # Run FastAPI (port 8001) + static site (port 8000) locally
 make add-notes-table # Create notes table in SQLite DB (idempotent)
+make add-capture-table # Create capture_events table in SQLite DB (idempotent, legacy — migration v8 auto-runs on startup)
 .venv/bin/python scripts/generate_llm.py --db data/bookshelf.db --provider gemini
                      # Refresh only Gemini recommendations
+.venv/bin/python -m api.telegram_bot
+                     # Run the Telegram capture bot locally (requires TELEGRAM_BOT_TOKEN + TELEGRAM_ALLOWED_CHAT_ID)
 ```
 
 **Deploy:**
 ```bash
-make deploy          # backup VPS DB → rsync code → restart API
+make deploy          # backup VPS DB → rsync code → restart API → restart telegram bot (if installed)
 make deploy-staging  # rsync code → restart staging API
+```
+
+**Telegram capture bot (VPS):**
+```bash
+make bot-status      # SSH: systemctl status bookshelf-telegram-bot
+make bot-logs        # SSH: journalctl -u bookshelf-telegram-bot -f
+make bot-restart     # SSH: systemctl restart bookshelf-telegram-bot
 ```
 
 **Database management:**
@@ -53,12 +63,22 @@ make seed-staging    # SSH: copy prod DB → staging DB on VPS
 - `api/main.py` — FastAPI server; reads from SQLite via `BookshelfDB` (or JSON via `BookshelfStore` as fallback)
 - `api/auth.py` — Bearer token auth; checks `auth_tokens` table in SQLite, falls back to `BOOKSHELF_AUTH_TOKEN` env var
 - `api/notes.py` — Notes CRUD endpoints (`GET`/`POST`/`PUT`/`DELETE` on `/api/books/{id}/notes`)
+- `api/capture.py` — Capture triage endpoints (`GET`/`PUT` on `/api/capture`, `POST /api/capture/{id}/apply`, `POST /api/capture/{id}/discard`)
+- `api/telegram_bot.py` — Long-polling Telegram bot that inserts inbound messages into the `capture_events` table; runs as a separate systemd service (`bookshelf-telegram-bot`) on the VPS
 - `api/google_books.py` — Google Books API search for the lookup endpoint
 - `api/sync.py` — Goodreads RSS sync (deprecated, returns 410)
 - `site/index.html` — single-file frontend (vanilla JS + embedded CSS); fetches `/api/*` endpoints; clicking a book navigates to its detail page
 - `site/book.html` — individual book detail page with notes display and inline note add/edit/delete (auth required for writes)
 - `site/add.html` — add book form with Google Books lookup
 - `site/edit.html` — edit book form with delete
+- `site/inbox.html` — triage UI for pending captures; each card lets you pick a book, note type, content, page, and tags, then apply (creates a note) or discard
+
+**Mobile capture pipeline:**
+1. User texts a Telegram bot from their phone → `api/telegram_bot.py` validates the sender against `TELEGRAM_ALLOWED_CHAT_ID` and inserts the raw message into `capture_events` with `status='pending'`.
+2. User opens `/inbox` on the site, which lists pending captures via `GET /api/capture`.
+3. For each capture, the user fills in resolved fields (book, note_type, content, page, tags) and hits Apply. The frontend calls `PUT /api/capture/{id}` to persist the resolution, then `POST /api/capture/{id}/apply` to materialize a note and an `activity_log` entry. The note's `created_at` is backdated to the capture's original timestamp.
+4. Unwanted captures are dismissed via `POST /api/capture/{id}/discard`.
+5. The `capture_events` table is created by migration v8 in `db.py` and auto-runs on API startup; `make add-capture-table` / `scripts/add_capture_table.py` exist for legacy one-shot bootstrap but are not needed for normal deploys.
 
 **Shared utilities (`bookshelf_data.py`):**
 - `load_env_file()` — custom `.env` parser (no python-dotenv dependency)
@@ -75,7 +95,35 @@ make seed-staging    # SSH: copy prod DB → staging DB on VPS
 1. Make code changes locally (including new migrations in `db.py` if needed)
 2. `make deploy-staging` → rsync code → restart → migrations auto-run on startup
 3. Verify on `dev.book.tanxy.net`
-4. `make deploy` → backup VPS DB → rsync code → restart → migrations auto-run
+4. `make deploy` → backup VPS DB → rsync code → restart API → restart telegram bot (if installed) → migrations auto-run
+
+`make deploy` chains `backup → deploy-sync → restart-api → restart-bot`. The `restart-bot` step is idempotent: it checks `systemctl list-unit-files` and silently skips if `bookshelf-telegram-bot.service` is not installed, so deploys stay green before the first-time bot install.
+
+**First-time Telegram bot install (VPS, one-time per host):**
+
+The telegram bot runs as a separate systemd service from the API. The code and unit file are rsynced by `make deploy-sync`, but the package install, env vars, and `systemctl enable` must be done by hand once:
+
+1. Ensure `python-telegram-bot>=21.0` is importable by the VPS venv:
+   ```bash
+   ssh root@134.199.239.64 '/var/www/book.tanxy.net/.venv/bin/pip install "python-telegram-bot>=21.0"'
+   ```
+2. Add the bot credentials to `/etc/bookshelf.env` (or whatever `EnvironmentFile` the unit points at):
+   ```
+   TELEGRAM_BOT_TOKEN=<from @BotFather>
+   TELEGRAM_ALLOWED_CHAT_ID=<your personal chat id>
+   ```
+3. Install the systemd unit (rsynced to `$VPS_PATH/deploy/telegram-bot.service` by `make deploy-sync`):
+   ```bash
+   ssh root@134.199.239.64 '
+     cp /var/www/book.tanxy.net/deploy/telegram-bot.service /etc/systemd/system/bookshelf-telegram-bot.service &&
+     systemctl daemon-reload &&
+     systemctl enable --now bookshelf-telegram-bot
+   '
+   ```
+4. Verify: `make bot-status` → should show `active (running)`. Send a test message to the bot and check `make bot-logs`.
+5. After the first install, subsequent `make deploy` runs pick the bot up automatically via `restart-bot`.
+
+Staging currently has no bot service — captures only come in against production. If you want a staging bot, repeat the steps above against `STAGING_VPS_PATH` with a second `TELEGRAM_BOT_TOKEN`.
 
 **If a migration fails on startup:**
 1. API won't start, but `make backup` already saved the pre-migration DB
@@ -105,6 +153,8 @@ Loaded automatically from `.env` at repo root via `load_env_file()`. See `.env.e
 | `GOODREADS_USER_ID` | — | Required for `POST /api/sync` |
 | `BOOKSHELF_AUTH_TOKEN` | — | Bearer token for write endpoints; also checked against `auth_tokens` table in SQLite |
 | `BOOKSHELF_CORS_ORIGINS` | — | Comma-separated allowed origins |
+| `TELEGRAM_BOT_TOKEN` | — | Required for `api/telegram_bot.py`; obtained from @BotFather |
+| `TELEGRAM_ALLOWED_CHAT_ID` | — | Required for `api/telegram_bot.py`; numeric chat ID allowed to send captures — all other senders are ignored |
 
 ## API Endpoints
 
@@ -122,6 +172,10 @@ DELETE /api/books/{id}         # Delete a book (auth required, SQLite only)
 POST   /api/books/{id}/notes   # Add a note (auth required)
 PUT    /api/books/{id}/notes/{note_id}    # Update a note (auth required)
 DELETE /api/books/{id}/notes/{note_id}    # Delete a note (auth required)
+GET    /api/capture            # List capture events (auth required; ?status=pending|applied|discarded, default pending)
+PUT    /api/capture/{id}       # Update resolved_* fields on a pending capture (auth required)
+POST   /api/capture/{id}/apply # Materialize capture as a note + activity_log entry (auth required)
+POST   /api/capture/{id}/discard # Mark capture as discarded (auth required)
 POST   /api/llm/regenerate     # Trigger async LLM regeneration (auth required)
 POST   /api/sync               # Deprecated (returns 410 Gone)
 ```
@@ -135,3 +189,4 @@ POST   /api/sync               # Deprecated (returns 410 Gone)
 - **Auth**: Write endpoints require `Authorization: Bearer <token>`. Tokens are stored as SHA-256 hashes in the `auth_tokens` table. The env var `BOOKSHELF_AUTH_TOKEN` is a fallback when no SQLite DB is available.
 - **LLM regeneration**: Write operations on the "read" shelf automatically trigger async LLM regeneration. An `asyncio.Lock` prevents concurrent runs.
 - **Notes**: Per-book notes stored in the `notes` table with types: `thought`, `quote`, `connection`, `disagreement`, `question`. Tags stored as JSON array strings. Connection notes can link to another book via `connected_source_id`. The `source_type` field is always `'book'` for now (future-proofed for other content types). Notes do NOT trigger LLM regeneration.
+- **Mobile capture**: Captures live in `capture_events` with lifecycle `pending → applied | discarded`. Pending rows only hold `raw_text` + `source_channel`. Applying a capture writes the resolved fields, creates a note, and creates an `activity_log` entry with `event_type='note_added'`. The note's `created_at` is backdated to the capture's original `created_at` so the activity feed reflects *when the thought happened*, not when it was triaged. Double-apply returns 400.

--- a/README.md
+++ b/README.md
@@ -90,9 +90,11 @@ bookshelf/
 │   ├── main.py                # FastAPI app (books, health, lookup, LLM endpoints)
 │   ├── activity.py            # Public activity feed endpoint
 │   ├── auth.py                # Bearer-token auth
+│   ├── capture.py             # Capture triage endpoints (inbox)
 │   ├── email_delivery.py      # SMTP notification helpers
 │   ├── notes.py               # Notes CRUD endpoints
 │   ├── suggestions.py         # Public book-suggestion submission endpoint
+│   ├── telegram_bot.py        # Long-polling Telegram bot that writes to capture_events
 │   ├── google_books.py        # Google Books lookup
 │   ├── sync.py                # Legacy Goodreads RSS sync helpers
 │   └── requirements.txt
@@ -104,6 +106,7 @@ bookshelf/
 ├── deploy/
 │   ├── bookshelf.service
 │   ├── bookshelf-staging.service
+│   ├── telegram-bot.service   # Systemd unit for the Telegram capture bot
 │   ├── nginx.conf
 │   ├── nginx.staging.conf
 │   ├── nginx.bootstrap.conf
@@ -111,6 +114,7 @@ bookshelf/
 │   └── staging.env.example
 ├── scripts/
 │   ├── add_notes_table.py     # Legacy helper for notes schema bootstrapping
+│   ├── add_capture_table.py   # Legacy helper for capture_events schema bootstrapping
 │   ├── generate_llm.py
 │   ├── migrate_json_to_sqlite.py
 │   ├── parse_goodreads.py
@@ -121,6 +125,7 @@ bookshelf/
 │   ├── log.html               # Public activity log page
 │   ├── add.html               # Add book form
 │   ├── edit.html              # Edit book form
+│   ├── inbox.html             # Mobile-capture triage UI
 │   └── data/                  # Local static data during development
 ├── bookshelf_data.py          # Storage abstraction (SQLite or JSON fallback)
 ├── db.py                      # Schema, migrations, and DB helpers
@@ -162,6 +167,8 @@ Common optional settings:
 - `ANTHROPIC_MODEL`
 - `OPENAI_MODEL`
 - `GEMINI_MODEL`
+- `TELEGRAM_BOT_TOKEN` — required for the Telegram capture bot (from @BotFather)
+- `TELEGRAM_ALLOWED_CHAT_ID` — required for the Telegram capture bot; the only chat ID whose messages are accepted
 
 ## Local development
 
@@ -209,6 +216,7 @@ make llm                   # generate/update LLM cache from books.json
 make llm-force             # force regenerate LLM cache
 make build                 # parse + llm
 make add-notes-table       # legacy helper for notes schema creation
+make add-capture-table     # legacy helper for capture_events schema creation
 ```
 
 Useful direct commands:
@@ -261,6 +269,35 @@ The homepage suggestion modal stores each submission in `book_suggestions`.
 
 This keeps the visitor interaction path durable even when mail delivery is unavailable.
 
+## Mobile capture (Telegram bot)
+
+Reading thoughts mostly happen away from a desk. The mobile capture flow lets the site owner dump raw snippets into a Telegram chat with a private bot and triage them into structured notes later, from any browser.
+
+### Flow
+
+1. Phone → Telegram bot: the owner sends any plain-text message to the bot.
+2. `api/telegram_bot.py` (long-polling, runs as its own systemd service) checks the sender against `TELEGRAM_ALLOWED_CHAT_ID` and inserts the raw text into `capture_events` with `status = pending` and `source_channel = telegram`. All other senders are silently ignored.
+3. Later, on any browser, the owner opens `/inbox` (linked from the admin nav when authed). This page lists all pending captures via `GET /api/capture`.
+4. For each capture, the owner picks a book, a note type (`thought`, `quote`, `connection`, `disagreement`, `question`), fills in content, optional page, and optional tags, then hits Apply. The frontend calls `PUT /api/capture/{id}` to persist the resolution and `POST /api/capture/{id}/apply` to materialize a real note plus an `activity_log` entry.
+5. The materialized note's `created_at` is backdated to the capture's original timestamp, so the activity feed shows when the thought *happened*, not when it was triaged.
+6. Captures that don't deserve a note are dismissed via `POST /api/capture/{id}/discard`.
+
+### Data
+
+- Lives in the `capture_events` table, created by migration v8 in `db.py` (auto-runs on API startup).
+- Lifecycle: `pending → applied | discarded`. Applied captures are soft-retained with a reference to the note they became.
+
+### Local bot
+
+```bash
+TELEGRAM_BOT_TOKEN=... TELEGRAM_ALLOWED_CHAT_ID=... \
+  ./.venv/bin/python -m api.telegram_bot
+```
+
+### VPS setup
+
+See the `## Deploy` section for the one-time bot install steps. After that, `make deploy` picks the bot up automatically; `make bot-status`, `make bot-logs`, and `make bot-restart` are the operational shortcuts.
+
 ## API
 
 Public read endpoints:
@@ -286,6 +323,10 @@ DELETE /api/books/{id}
 POST   /api/books/{id}/notes
 PUT    /api/books/{id}/notes/{note_id}
 DELETE /api/books/{id}/notes/{note_id}
+GET    /api/capture
+PUT    /api/capture/{id}
+POST   /api/capture/{id}/apply
+POST   /api/capture/{id}/discard
 POST   /api/llm/regenerate
 ```
 
@@ -372,15 +413,45 @@ make deploy-staging
 make deploy
 ```
 
+`make deploy` chains `backup → deploy-sync → restart-api → restart-bot`. The `restart-bot` step is idempotent — it checks `systemctl list-unit-files` and skips quietly if the telegram bot service is not installed on the host yet.
+
 ### Deploy commands
 
 ```bash
-make deploy                # backup prod DB -> sync code -> restart prod API
+make deploy                # backup prod DB -> sync code -> restart prod API -> restart telegram bot (if installed)
 make deploy-staging        # sync code -> restart staging API
 make backup                # snapshot production DB on the VPS
 make restart-api
 make restart-staging-api
+make bot-status            # status of the Telegram capture bot
+make bot-logs              # tail Telegram capture bot logs
+make bot-restart           # restart the Telegram capture bot
 ```
+
+### First-time Telegram bot install (one-time, per VPS)
+
+`make deploy-sync` already rsyncs `api/telegram_bot.py` and `deploy/telegram-bot.service` to the VPS, but the Python package, environment variables, and systemd enable step need to be done by hand once:
+
+1. Install the bot library into the production venv:
+   ```bash
+   ssh root@134.199.239.64 '/var/www/book.tanxy.net/.venv/bin/pip install "python-telegram-bot>=21.0"'
+   ```
+2. Add the bot credentials to the environment file referenced by the unit (e.g. `/etc/bookshelf.env`):
+   ```text
+   TELEGRAM_BOT_TOKEN=<from @BotFather>
+   TELEGRAM_ALLOWED_CHAT_ID=<your personal chat id>
+   ```
+3. Install and enable the systemd unit:
+   ```bash
+   ssh root@134.199.239.64 '
+     cp /var/www/book.tanxy.net/deploy/telegram-bot.service /etc/systemd/system/bookshelf-telegram-bot.service &&
+     systemctl daemon-reload &&
+     systemctl enable --now bookshelf-telegram-bot
+   '
+   ```
+4. Verify: `make bot-status` → `active (running)`. Send a test message to the bot, open `/inbox` on the site, and confirm it shows up as a pending capture.
+
+After the first install, routine `make deploy` runs keep the bot in sync — the unit file is rsynced and `restart-bot` picks up new code automatically.
 
 ### Database sync commands
 


### PR DESCRIPTION
## Summary
- Adds CLAUDE.md and README.md coverage for the mobile capture pipeline (Task 5 of the mobile-capture spec)
- Documents the Telegram bot architecture, first-time VPS install, new make targets, `/api/capture` endpoints, and the two new `TELEGRAM_*` env vars
- Docs-only — no code or schema changes

## What's documented
- **Architecture**: `api/capture.py`, `api/telegram_bot.py`, `site/inbox.html`, and the pending → applied/discarded capture lifecycle (with the backdated-note-timestamp detail)
- **Deploy workflow**: the idempotent `restart-bot` step, and the one-time VPS install (pip install `python-telegram-bot`, `/etc/bookshelf.env` credentials, systemd unit copy + enable)
- **Commands**: `make bot-status`, `make bot-logs`, `make bot-restart`, `make add-capture-table`, and running the bot locally via `python -m api.telegram_bot`
- **API reference**: GET/PUT/POST endpoints under `/api/capture`
- **Env vars**: `TELEGRAM_BOT_TOKEN`, `TELEGRAM_ALLOWED_CHAT_ID`

Refs #28

## Test plan
- [x] Skim CLAUDE.md diff for accuracy
- [ ] Skim README.md diff for accuracy
- [ ] Confirm the first-time-install steps match what we'll actually run on the VPS when we flip the bot on

🤖 Generated with [Claude Code](https://claude.com/claude-code)