### PR TITLE
[codex] Hide deleted notes from the public activity log

### DIFF
--- a/api/activity.py
+++ b/api/activity.py
@@ -65,6 +65,10 @@ def _serialize_row(
     return payload
 
 
+def _is_public_row(row: dict[str, Any]) -> bool:
+    return row.get("event_type") != "note_added" or bool(row.get("note_exists"))
+
+
 def _list_all_activity_rows(conn) -> list[dict[str, Any]]:
     rows: list[dict[str, Any]] = []
     offset = 0
@@ -157,15 +161,15 @@ async def get_activity(
 
     conn = store.conn()
     requested_view = (view or "").strip().lower()
+    rows = [row for row in _list_all_activity_rows(conn) if _is_public_row(row)]
 
     if requested_view == "preview":
-        items = _serialize_preview_rows(_list_all_activity_rows(conn))
-        has_more = len(items) > offset + limit
-        visible_items = items[offset:offset + limit]
+        serialized_items = _serialize_preview_rows(rows)
     else:
-        rows = list_activity_rows(conn, limit=limit + 1, offset=offset)
-        has_more = len(rows) > limit
-        visible_items = [_serialize_row(row) for row in rows[:limit]]
+        serialized_items = [_serialize_row(row) for row in rows]
+
+    has_more = len(serialized_items) > offset + limit
+    visible_items = serialized_items[offset:offset + limit]
 
     return {
         "items": visible_items,

--- a/db.py
+++ b/db.py
@@ -444,9 +444,11 @@ def list_activity_rows(
                activity_log.book_author,
                activity_log.note_type,
                activity_log.created_at,
-               CASE WHEN books.id IS NULL THEN 0 ELSE 1 END AS book_exists
+               CASE WHEN books.id IS NULL THEN 0 ELSE 1 END AS book_exists,
+               CASE WHEN notes.id IS NULL THEN 0 ELSE 1 END AS note_exists
            FROM activity_log
            LEFT JOIN books ON books.id = activity_log.book_id
+           LEFT JOIN notes ON notes.id = activity_log.note_id
            ORDER BY activity_log.created_at DESC, activity_log.id DESC
            LIMIT ? OFFSET ?""",
         (limit, offset),

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1021,6 +1021,53 @@ class ApiSqliteTests(unittest.TestCase):
         self.assertEqual(activity[0]["note_type"], "quote")
         self.assertEqual(activity[0]["summary"], "Added a quote from Dune")
 
+    def test_delete_note_hides_note_added_from_activity(self):
+        create = self.client.post(
+            "/api/books/1/notes",
+            json={"note_type": "thought", "content": "First note."},
+            headers=TEST_AUTH_HEADER,
+        )
+        note_id = create.json()["id"]
+
+        delete = self.client.delete(
+            f"/api/books/1/notes/{note_id}",
+            headers=TEST_AUTH_HEADER,
+        )
+
+        self.assertEqual(create.status_code, 201)
+        self.assertEqual(delete.status_code, 200)
+        self.assertEqual(self.client.get("/api/activity?limit=10").json()["items"], [])
+
+        conn = get_connection(self.db_path)
+        rows = conn.execute(
+            "SELECT event_type, note_id FROM activity_log WHERE note_id = ?",
+            (note_id,),
+        ).fetchall()
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["event_type"], "note_added")
+        self.assertEqual(rows[0]["note_id"], note_id)
+        conn.close()
+
+    def test_delete_note_hides_note_added_from_preview_activity(self):
+        create = self.client.post(
+            "/api/books/1/notes",
+            json={"note_type": "thought", "content": "First note."},
+            headers=TEST_AUTH_HEADER,
+        )
+        note_id = create.json()["id"]
+
+        delete = self.client.delete(
+            f"/api/books/1/notes/{note_id}",
+            headers=TEST_AUTH_HEADER,
+        )
+
+        self.assertEqual(create.status_code, 201)
+        self.assertEqual(delete.status_code, 200)
+        self.assertEqual(
+            self.client.get("/api/activity?view=preview&limit=10").json()["items"],
+            [],
+        )
+
     def test_activity_preview_collapses_same_day_notes_per_book(self):
         for content in ("First note.", "Second note.", "Third note."):
             resp = self.client.post(
@@ -1039,6 +1086,29 @@ class ApiSqliteTests(unittest.TestCase):
         self.assertEqual(preview[0]["summary"], "Added 3 notes on Dune")
         self.assertEqual(preview[0]["created_at"], raw[0]["created_at"])
         self.assertNotIn("note_type", preview[0])
+
+    def test_activity_preview_burst_count_shrinks_when_note_is_deleted(self):
+        note_ids = []
+        for content in ("First note.", "Second note.", "Third note."):
+            resp = self.client.post(
+                "/api/books/1/notes",
+                json={"note_type": "thought", "content": content},
+                headers=TEST_AUTH_HEADER,
+            )
+            self.assertEqual(resp.status_code, 201)
+            note_ids.append(resp.json()["id"])
+
+        before_delete = self.client.get("/api/activity?view=preview&limit=10").json()["items"]
+        delete = self.client.delete(
+            f"/api/books/1/notes/{note_ids[0]}",
+            headers=TEST_AUTH_HEADER,
+        )
+        after_delete = self.client.get("/api/activity?view=preview&limit=10").json()["items"]
+
+        self.assertEqual(delete.status_code, 200)
+        self.assertEqual(before_delete[0]["summary"], "Added 3 notes on Dune")
+        self.assertEqual(len(after_delete), 1)
+        self.assertEqual(after_delete[0]["summary"], "Added 2 notes on Dune")
 
     def test_activity_preview_does_not_collapse_notes_across_pacific_days(self):
         first = self.client.post(
@@ -1188,6 +1258,42 @@ class ApiSqliteTests(unittest.TestCase):
         self.assertFalse(second_page["pagination"]["has_more"])
         self.assertEqual(second_page["items"][0]["summary"], "Added Preview Fourth to to-read")
 
+    def test_activity_pagination_backfills_past_deleted_note_entries(self):
+        for title in ("First", "Second", "Third"):
+            resp = self.client.post(
+                "/api/books",
+                json={"title": title, "author": "Author", "exclusive_shelf": "to_read"},
+                headers=TEST_AUTH_HEADER,
+            )
+            self.assertEqual(resp.status_code, 201)
+
+        create = self.client.post(
+            "/api/books/1/notes",
+            json={"note_type": "thought", "content": "Transient note."},
+            headers=TEST_AUTH_HEADER,
+        )
+        note_id = create.json()["id"]
+        delete = self.client.delete(
+            f"/api/books/1/notes/{note_id}",
+            headers=TEST_AUTH_HEADER,
+        )
+
+        self.assertEqual(create.status_code, 201)
+        self.assertEqual(delete.status_code, 200)
+
+        first_page = self.client.get("/api/activity?limit=3&offset=0").json()
+
+        self.assertEqual(len(first_page["items"]), 3)
+        self.assertFalse(first_page["pagination"]["has_more"])
+        self.assertEqual(
+            [item["summary"] for item in first_page["items"]],
+            [
+                "Added Third to to-read",
+                "Added Second to to-read",
+                "Added First to to-read",
+            ],
+        )
+
     def test_homepage_activity_preview_requests_preview_view(self):
         homepage = (ROOT / "site/index.html").read_text(encoding="utf-8")
         self.assertIn("fetchJson('/api/activity?view=preview&limit=3')", homepage)
@@ -1322,9 +1428,15 @@ class ApiSqliteTests(unittest.TestCase):
 
         self.assertEqual(update.status_code, 200)
         self.assertEqual(delete.status_code, 200)
-        activity = self.client.get("/api/activity?limit=10").json()["items"]
-        self.assertEqual(len(activity), 1)
-        self.assertEqual(activity[0]["event_type"], "note_added")
+        self.assertEqual(self.client.get("/api/activity?limit=10").json()["items"], [])
+
+        conn = get_connection(self.db_path)
+        rows = conn.execute(
+            "SELECT event_type FROM activity_log WHERE note_id = ? ORDER BY id",
+            (note_id,),
+        ).fetchall()
+        self.assertEqual([row["event_type"] for row in rows], ["note_added"])
+        conn.close()
 
     def test_failed_note_creation_does_not_log_activity(self):
         resp = self.client.post(


### PR DESCRIPTION
## Summary
- hide `note_added` activity when the referenced note has been deleted
- keep `activity_log` append-only by filtering deleted-note rows in the public activity API instead of mutating history
- add regression coverage for delete visibility, preview burst shrink, and pagination backfill

## Why
Deleting a note from the book page currently removes the note itself but leaves its old public activity entry visible. That makes the site feel inconsistent because the feed references content that no longer exists.

Closes #42

## Validation
- `/Users/xinyutan/Documents/projects/bookshelf/.venv/bin/python -m unittest tests.test_db.ApiSqliteTests`
- `/Users/xinyutan/Documents/projects/bookshelf/.venv/bin/python -m unittest tests.test_api`
- manual deploy verification on staging and production before merge
