### PR TITLE
[codex] Add multiple read periods for books

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -363,6 +363,8 @@ async def create_book(request: Request) -> dict:
         "google_books_id": body.get("google_books_id") or None,
         "goodreads_id": body.get("goodreads_id") or None,
     }
+    if "read_events" in body:
+        book_data["read_events"] = body.get("read_events")
 
     conn = store.conn()
     try:
@@ -372,6 +374,9 @@ async def create_book(request: Request) -> dict:
             raise HTTPException(status_code=500, detail="Book was created but could not be loaded.")
         _log_book_activity(conn, event_type=_created_book_activity_type(shelf), book=book)
         conn.commit()
+    except ValueError as exc:
+        conn.rollback()
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
     except Exception:
         conn.rollback()
         raise
@@ -385,7 +390,7 @@ async def update_book_endpoint(book_id: int, request: Request) -> dict:
     if not USE_SQLITE:
         raise HTTPException(status_code=400, detail="CRUD requires SQLite backend.")
 
-    from db import get_book_by_id, update_book
+    from db import get_book_by_id, replace_read_events, update_book
 
     existing = get_book_by_id(store.conn(), book_id)
     if existing is None:
@@ -397,11 +402,21 @@ async def update_book_endpoint(book_id: int, request: Request) -> dict:
 
     if "shelves" in body:
         body["shelves"] = _normalize_shelves(body.get("shelves"))
+    has_read_events = "read_events" in body
+    read_events = body.pop("read_events", None)
+    if has_read_events:
+        body.pop("date_read", None)
+    elif "date_read" in body:
+        # Read history is now the source of truth for updates. Keeping this out
+        # prevents stale single-date clients from desynchronizing the cache field.
+        body.pop("date_read", None)
 
     conn = store.conn()
     try:
         if not update_book(conn, book_id, body):
             raise HTTPException(status_code=404, detail="Book not found.")
+        if has_read_events:
+            replace_read_events(conn, book_id, read_events)
         updated = get_book_by_id(conn, book_id)
         if updated is None:
             raise HTTPException(status_code=404, detail="Book not found.")
@@ -413,6 +428,9 @@ async def update_book_endpoint(book_id: int, request: Request) -> dict:
             book=updated,
         )
         conn.commit()
+    except ValueError as exc:
+        conn.rollback()
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
     except Exception:
         conn.rollback()
         raise

--- a/bookshelf_data.py
+++ b/bookshelf_data.py
@@ -4,6 +4,7 @@ import hashlib
 import json
 import os
 import sqlite3
+import threading
 from collections import Counter
 from copy import deepcopy
 from datetime import datetime, timezone
@@ -61,6 +62,8 @@ def default_books_payload() -> dict[str, Any]:
             "currently_reading_count": 0,
             "avg_my_rating": 0.0,
             "books_this_year": 0,
+            "read_completions": 0,
+            "read_completions_this_year": 0,
             "top_authors": [],
         },
     }
@@ -129,6 +132,14 @@ def normalize_book_key(title: str, author: str) -> tuple[str, str]:
 
 
 def _book_hash_entry(book: dict[str, Any], shelf_key: str) -> list[Any]:
+    read_events = [
+        [
+            (event.get("started_on") or "").strip(),
+            (event.get("finished_on") or "").strip(),
+        ]
+        for event in (book.get("read_events") or [])
+        if isinstance(event, dict)
+    ]
     return [
         shelf_key,
         (book.get("title") or "").strip(),
@@ -136,6 +147,7 @@ def _book_hash_entry(book: dict[str, Any], shelf_key: str) -> list[Any]:
         int(book.get("my_rating") or 0),
         (book.get("my_review") or "").strip(),
         (book.get("date_read") or "").strip(),
+        sorted(read_events),
         (book.get("date_added") or "").strip(),
         sorted(str(shelf).strip() for shelf in (book.get("shelves") or []) if str(shelf).strip()),
     ]
@@ -303,7 +315,35 @@ class BookshelfStore:
         self.llm_cache_file = JsonFileCache(llm_cache_path, default_llm_cache)
 
     def books(self) -> dict[str, Any]:
-        return self.books_file.read()
+        payload = self.books_file.read()
+        for shelf in payload.get("books", {}).values():
+            if not isinstance(shelf, list):
+                continue
+            for book in shelf:
+                if not isinstance(book, dict):
+                    continue
+                if not isinstance(book.get("read_events"), list):
+                    book["read_events"] = (
+                        [{"id": None, "started_on": "", "finished_on": book.get("date_read") or ""}]
+                        if book.get("date_read")
+                        else []
+                    )
+
+        read_books = payload.get("books", {}).get("read", [])
+        if isinstance(read_books, list):
+            stats = payload.setdefault("stats", {})
+            current_year = datetime.now().year
+            events = [
+                event
+                for book in read_books
+                for event in (book.get("read_events") or [])
+                if isinstance(event, dict) and event.get("finished_on")
+            ]
+            stats["read_completions"] = len(events)
+            stats["read_completions_this_year"] = sum(
+                1 for event in events if str(event.get("finished_on") or "").startswith(str(current_year))
+            )
+        return payload
 
     def llm_cache(self) -> dict[str, Any]:
         return self.llm_cache_file.read()
@@ -330,15 +370,18 @@ class BookshelfDB:
         from db import get_connection, run_migrations
 
         self.db_path = db_path
-        self._conn: sqlite3.Connection | None = None
+        self._connections: dict[int, sqlite3.Connection] = {}
         self._get_connection = get_connection
         self._run_migrations = run_migrations
 
     def conn(self) -> sqlite3.Connection:
-        if self._conn is None:
-            self._conn = self._get_connection(self.db_path)
-            self._run_migrations(self._conn)
-        return self._conn
+        thread_id = threading.get_ident()
+        conn = self._connections.get(thread_id)
+        if conn is None:
+            conn = self._get_connection(self.db_path)
+            self._run_migrations(conn)
+            self._connections[thread_id] = conn
+        return conn
 
     def _row_to_book(self, row: sqlite3.Row) -> dict[str, Any]:
         """Convert a DB row to the dict format matching books.json entries."""
@@ -360,6 +403,13 @@ class BookshelfDB:
         d["date_added"] = d.get("date_added") or ""
         d["goodreads_id"] = d.get("goodreads_id") or ""
         d["my_rating"] = d.get("my_rating") or 0
+        d["read_events"] = []
+        if d.get("id"):
+            from db import list_read_events
+
+            d["read_events"] = list_read_events(self.conn(), d["id"])
+        if not d["read_events"] and d["date_read"]:
+            d["read_events"] = [{"id": None, "started_on": "", "finished_on": d["date_read"]}]
 
         return d
 
@@ -390,6 +440,16 @@ class BookshelfDB:
             1 for b in read_books
             if (b.get("date_read") or "").startswith(str(current_year))
         )
+        read_events = [
+            event
+            for book in read_books
+            for event in (book.get("read_events") or [])
+            if isinstance(event, dict) and event.get("finished_on")
+        ]
+        completions_this_year = sum(
+            1 for event in read_events
+            if str(event.get("finished_on") or "").startswith(str(current_year))
+        )
         top_authors = [
             {"author": a, "count": c}
             for a, c in Counter(
@@ -399,6 +459,8 @@ class BookshelfDB:
         return {
             "total_read": len(read_books),
             "books_this_year": this_year,
+            "read_completions": len(read_events),
+            "read_completions_this_year": completions_this_year,
             "avg_my_rating": avg,
             "top_authors": top_authors,
             "total_to_read": to_read_count,

--- a/db.py
+++ b/db.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import json
 import sqlite3
+from datetime import date
 from pathlib import Path
 from typing import Any, Callable
 
@@ -223,6 +224,55 @@ def _migration_v8(conn: sqlite3.Connection) -> None:
     conn.executescript(_CAPTURE_EVENTS_SCHEMA)
 
 
+_BOOK_READ_EVENTS_SCHEMA = """
+CREATE TABLE IF NOT EXISTS book_read_events (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    book_id INTEGER NOT NULL,
+    started_on TEXT,
+    finished_on TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+    updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+    FOREIGN KEY (book_id) REFERENCES books(id) ON DELETE CASCADE,
+    CHECK (started_on IS NULL OR started_on = '' OR started_on <= finished_on)
+);
+
+CREATE INDEX IF NOT EXISTS idx_book_read_events_book_finished
+    ON book_read_events(book_id, finished_on DESC, id DESC);
+CREATE INDEX IF NOT EXISTS idx_book_read_events_finished
+    ON book_read_events(finished_on DESC);
+"""
+
+
+def _migration_v9(conn: sqlite3.Connection) -> None:
+    conn.executescript(_BOOK_READ_EVENTS_SCHEMA)
+    conn.execute(
+        """INSERT INTO book_read_events (book_id, finished_on)
+           SELECT books.id, books.date_read
+           FROM books
+           WHERE books.date_read IS NOT NULL
+             AND books.date_read != ''
+             AND NOT EXISTS (
+                 SELECT 1
+                 FROM book_read_events
+                 WHERE book_read_events.book_id = books.id
+                   AND book_read_events.finished_on = books.date_read
+             )"""
+    )
+    conn.execute(
+        """UPDATE books
+           SET date_read = (
+               SELECT MAX(finished_on)
+               FROM book_read_events
+               WHERE book_read_events.book_id = books.id
+           )
+           WHERE EXISTS (
+               SELECT 1
+               FROM book_read_events
+               WHERE book_read_events.book_id = books.id
+           )"""
+    )
+
+
 MIGRATIONS: list[tuple[int, Callable[[sqlite3.Connection], None]]] = [
     (1, _migration_v1),
     (2, _migration_v2),
@@ -232,6 +282,7 @@ MIGRATIONS: list[tuple[int, Callable[[sqlite3.Connection], None]]] = [
     (6, _migration_v6),
     (7, _migration_v7),
     (8, _migration_v8),
+    (9, _migration_v9),
 ]
 
 
@@ -309,8 +360,92 @@ def _row_to_book_dict(row: sqlite3.Row) -> dict[str, Any]:
     shelves_raw = d.pop("shelves", None)
     d["shelves"] = json.loads(shelves_raw) if shelves_raw else []
     # API returns my_review, not review, for frontend compat
-    d["my_review"] = d.pop("review", None)
+    d["my_review"] = d.pop("review", None) or ""
+    d["isbn13"] = d.get("isbn13") or ""
+    d["date_read"] = d.get("date_read") or ""
+    d["date_added"] = d.get("date_added") or ""
+    d["goodreads_id"] = d.get("goodreads_id") or ""
+    d["my_rating"] = d.get("my_rating") or 0
     return d
+
+
+def _normalize_date_value(value: Any, field_name: str, *, required: bool = False) -> str | None:
+    raw = str(value or "").strip()
+    if not raw:
+        if required:
+            raise ValueError(f"{field_name} is required.")
+        return None
+    try:
+        date.fromisoformat(raw)
+    except ValueError as exc:
+        raise ValueError(f"{field_name} must be a YYYY-MM-DD date.") from exc
+    return raw
+
+
+def normalize_read_events(raw_events: Any) -> list[dict[str, str | None]]:
+    if raw_events is None:
+        return []
+    if not isinstance(raw_events, list):
+        raise ValueError("read_events must be a list.")
+
+    normalized: list[dict[str, str | None]] = []
+    for idx, raw_event in enumerate(raw_events, start=1):
+        if not isinstance(raw_event, dict):
+            raise ValueError(f"read_events[{idx}] must be an object.")
+        started_on = _normalize_date_value(raw_event.get("started_on"), f"read_events[{idx}].started_on")
+        finished_on = _normalize_date_value(
+            raw_event.get("finished_on"),
+            f"read_events[{idx}].finished_on",
+            required=True,
+        )
+        if started_on and finished_on and started_on > finished_on:
+            raise ValueError(f"read_events[{idx}].started_on cannot be after finished_on.")
+        normalized.append({"started_on": started_on, "finished_on": finished_on})
+
+    return normalized
+
+
+def list_read_events(conn: sqlite3.Connection, book_id: int) -> list[dict[str, Any]]:
+    rows = conn.execute(
+        """SELECT id, book_id, started_on, finished_on, created_at, updated_at
+           FROM book_read_events
+           WHERE book_id = ?
+           ORDER BY finished_on DESC, id DESC""",
+        (book_id,),
+    ).fetchall()
+    events: list[dict[str, Any]] = []
+    for row in rows:
+        event = dict(row)
+        event["started_on"] = event.get("started_on") or ""
+        event["finished_on"] = event.get("finished_on") or ""
+        events.append(event)
+    return events
+
+
+def sync_book_latest_read_date(conn: sqlite3.Connection, book_id: int) -> None:
+    row = conn.execute(
+        "SELECT MAX(finished_on) AS latest FROM book_read_events WHERE book_id = ?",
+        (book_id,),
+    ).fetchone()
+    latest = row["latest"] if row else None
+    conn.execute(
+        """UPDATE books
+           SET date_read = ?, updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now')
+           WHERE id = ?""",
+        (latest, book_id),
+    )
+
+
+def replace_read_events(conn: sqlite3.Connection, book_id: int, raw_events: Any) -> None:
+    events = normalize_read_events(raw_events)
+    conn.execute("DELETE FROM book_read_events WHERE book_id = ?", (book_id,))
+    for event in events:
+        conn.execute(
+            """INSERT INTO book_read_events (book_id, started_on, finished_on)
+               VALUES (?, ?, ?)""",
+            (book_id, event["started_on"], event["finished_on"]),
+        )
+    sync_book_latest_read_date(conn, book_id)
 
 
 def insert_book(conn: sqlite3.Connection, book: dict[str, Any]) -> int:
@@ -338,12 +473,24 @@ def insert_book(conn: sqlite3.Connection, book: dict[str, Any]) -> int:
             book.get("google_books_id") or None,
         ),
     )
-    return cursor.lastrowid
+    book_id = cursor.lastrowid
+    if "read_events" in book:
+        replace_read_events(conn, book_id, book.get("read_events") or [])
+    elif book.get("date_read"):
+        replace_read_events(
+            conn,
+            book_id,
+            [{"started_on": None, "finished_on": book.get("date_read")}],
+        )
+    return book_id
 
 
 def get_books_by_shelf(conn: sqlite3.Connection, shelf: str) -> list[dict[str, Any]]:
     if shelf == "read":
-        order = "date_read DESC, date_added DESC"
+        order = """
+            CASE WHEN date_read IS NOT NULL AND date_read != '' THEN 0 ELSE 1 END,
+            date_read DESC, date_added DESC
+        """
     elif shelf == "currently_reading":
         order = "date_added DESC, date_read DESC"
     else:
@@ -353,14 +500,23 @@ def get_books_by_shelf(conn: sqlite3.Connection, shelf: str) -> list[dict[str, A
         f"SELECT * FROM books WHERE exclusive_shelf = ? ORDER BY {order}",
         (shelf,),
     ).fetchall()
-    return [_row_to_book_dict(row) for row in rows]
+    books = [_row_to_book_dict(row) for row in rows]
+    for book in books:
+        book["read_events"] = list_read_events(conn, book["id"])
+        if not book["read_events"] and book.get("date_read"):
+            book["read_events"] = [{"id": None, "started_on": "", "finished_on": book["date_read"]}]
+    return books
 
 
 def get_book_by_id(conn: sqlite3.Connection, book_id: int) -> dict[str, Any] | None:
     row = conn.execute("SELECT * FROM books WHERE id = ?", (book_id,)).fetchone()
     if row is None:
         return None
-    return _row_to_book_dict(row)
+    book = _row_to_book_dict(row)
+    book["read_events"] = list_read_events(conn, book_id)
+    if not book["read_events"] and book.get("date_read"):
+        book["read_events"] = [{"id": None, "started_on": "", "finished_on": book["date_read"]}]
+    return book
 
 
 def update_book(conn: sqlite3.Connection, book_id: int, fields: dict[str, Any]) -> bool:

--- a/scripts/migrate_json_to_sqlite.py
+++ b/scripts/migrate_json_to_sqlite.py
@@ -68,6 +68,8 @@ def migrate_books(conn, books_payload: dict) -> dict[str, int]:
                 "cover_url": None,
                 "google_books_id": None,
             }
+            if isinstance(book.get("read_events"), list):
+                book_data["read_events"] = book["read_events"]
 
             try:
                 insert_book(conn, book_data)

--- a/site/add.html
+++ b/site/add.html
@@ -451,7 +451,7 @@ document.getElementById('add-form').addEventListener('submit', async e => {
 
   if (isbn13) body.isbn13 = isbn13;
   if (pages) body.pages = parseInt(pages);
-  if (date_read) body.date_read = date_read;
+  if (date_read) body.read_events = [{ started_on: null, finished_on: date_read }];
   if (date_added) body.date_added = date_added;
   if (cover_url) body.cover_url = cover_url;
   if (my_review) body.my_review = my_review;

--- a/site/book.html
+++ b/site/book.html
@@ -121,6 +121,20 @@
       font-family: 'Cormorant Garamond', serif; font-size: 1.58rem; font-weight: 600;
       margin-bottom: 14px; color: rgba(52, 41, 34, 0.94);
     }
+    .read-history-list {
+      display: grid; gap: 9px;
+    }
+    .read-history-item {
+      padding: 11px 13px; border-radius: 14px;
+      border: 1px solid var(--border);
+      background: rgba(255, 252, 247, 0.72);
+      color: rgba(52, 41, 34, 0.94);
+      font-size: .95rem;
+    }
+    .read-history-item strong {
+      color: var(--accent-deep);
+      font-weight: 600;
+    }
     .review-text {
       line-height: 1.5;
       font-size: 1.03rem;
@@ -358,6 +372,10 @@
   <div class="loading" id="loading">Loading book...</div>
   <div id="content" style="display:none">
     <div class="hero" id="hero"></div>
+    <div class="section" id="read-history-section" style="display:none">
+      <h2 class="section-title">Read history</h2>
+      <div class="read-history-list" id="read-history-list"></div>
+    </div>
     <div class="section" id="review-section" style="display:none">
       <h2 class="section-title">Review</h2>
       <div class="review-text" id="review-text"></div>
@@ -407,6 +425,12 @@ function formatDate(dateStr) {
   if (!dateStr) return '';
   const d = new Date(dateStr + 'T00:00:00');
   return d.toLocaleDateString('en-US', { month: 'long', year: 'numeric' });
+}
+
+function formatFullDate(dateStr) {
+  if (!dateStr) return '';
+  const d = new Date(dateStr + 'T00:00:00');
+  return d.toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' });
 }
 
 function formatNoteDate(isoStr) {
@@ -463,6 +487,21 @@ function renderReview(book) {
     document.getElementById('review-text').textContent = review;
   }
   document.getElementById('review-section').style.display = '';
+}
+
+function renderReadHistory(book) {
+  const events = Array.isArray(book.read_events) ? book.read_events : [];
+  const finishedEvents = events.filter(event => event && event.finished_on);
+  if (!finishedEvents.length) return;
+
+  document.getElementById('read-history-list').innerHTML = finishedEvents.map(event => {
+    const finished = `<strong>Finished</strong> ${escHtml(formatFullDate(event.finished_on))}`;
+    if (!event.started_on) {
+      return `<div class="read-history-item">${finished}</div>`;
+    }
+    return `<div class="read-history-item"><strong>Started</strong> ${escHtml(formatFullDate(event.started_on))} &middot; ${finished}</div>`;
+  }).join('');
+  document.getElementById('read-history-section').style.display = '';
 }
 
 // ── Notes rendering ─────────────────────────────────────────────────────────
@@ -1045,6 +1084,7 @@ async function loadPage() {
     }
 
     renderHero(book);
+    renderReadHistory(book);
     renderReview(book);
     renderNotes(notes);
     renderAddNoteForm();

--- a/site/book.html
+++ b/site/book.html
@@ -426,10 +426,6 @@
   <div class="loading" id="loading">Loading book...</div>
   <div id="content" style="display:none">
     <div class="hero" id="hero"></div>
-    <div class="section" id="read-history-section" style="display:none">
-      <h2 class="section-title">Read history</h2>
-      <div class="read-history-list" id="read-history-list"></div>
-    </div>
     <div class="section" id="review-section" style="display:none">
       <h2 class="section-title">Review</h2>
       <div class="review-text" id="review-text"></div>
@@ -438,6 +434,10 @@
       <h2 class="section-title" id="notes-title">Notes</h2>
       <div id="add-note-wrap"></div>
       <div id="notes-list"></div>
+    </div>
+    <div class="section" id="read-history-section" style="display:none">
+      <h2 class="section-title">Read history</h2>
+      <div class="read-history-list" id="read-history-list"></div>
     </div>
   </div>
 </div>

--- a/site/book.html
+++ b/site/book.html
@@ -122,18 +122,72 @@
       margin-bottom: 14px; color: rgba(52, 41, 34, 0.94);
     }
     .read-history-list {
-      display: grid; gap: 9px;
+      position: relative;
+      display: grid;
+      gap: 14px;
+      padding-left: 24px;
+      max-width: 720px;
+    }
+    .read-history-list::before {
+      content: "";
+      position: absolute;
+      left: 7px;
+      top: 5px;
+      bottom: 5px;
+      width: 1px;
+      background: linear-gradient(
+        to bottom,
+        rgba(122, 92, 62, 0.08),
+        rgba(122, 92, 62, 0.28),
+        rgba(122, 92, 62, 0.08)
+      );
     }
     .read-history-item {
-      padding: 11px 13px; border-radius: 14px;
-      border: 1px solid var(--border);
-      background: rgba(255, 252, 247, 0.72);
+      position: relative;
+      display: flex;
+      flex-wrap: wrap;
+      align-items: baseline;
+      gap: 5px 12px;
+      min-height: 26px;
       color: rgba(52, 41, 34, 0.94);
       font-size: .95rem;
+    }
+    .read-history-item::before {
+      content: "";
+      position: absolute;
+      left: -21px;
+      top: .48em;
+      width: 9px;
+      height: 9px;
+      border-radius: 999px;
+      background: var(--bg);
+      border: 2px solid rgba(122, 92, 62, 0.48);
+      box-shadow: 0 0 0 4px rgba(255, 252, 247, 0.72);
+    }
+    .read-history-item:first-child::before {
+      border-color: var(--accent-deep);
+      background: rgba(122, 92, 62, 0.16);
     }
     .read-history-item strong {
       color: var(--accent-deep);
       font-weight: 600;
+    }
+    .read-history-label {
+      text-transform: uppercase;
+      letter-spacing: .11em;
+      font-size: .72rem;
+      color: rgba(132, 118, 109, 0.9);
+      font-weight: 700;
+    }
+    .read-history-date {
+      font-family: 'Cormorant Garamond', serif;
+      font-size: 1.12rem;
+      line-height: 1.1;
+      color: rgba(52, 41, 34, 0.96);
+    }
+    .read-history-separator {
+      color: rgba(122, 92, 62, 0.42);
+      font-size: .9rem;
     }
     .review-text {
       line-height: 1.5;
@@ -495,11 +549,21 @@ function renderReadHistory(book) {
   if (!finishedEvents.length) return;
 
   document.getElementById('read-history-list').innerHTML = finishedEvents.map(event => {
-    const finished = `<strong>Finished</strong> ${escHtml(formatFullDate(event.finished_on))}`;
+    const finished = `
+      <span class="read-history-label">Finished</span>
+      <span class="read-history-date">${escHtml(formatFullDate(event.finished_on))}</span>
+    `;
     if (!event.started_on) {
       return `<div class="read-history-item">${finished}</div>`;
     }
-    return `<div class="read-history-item"><strong>Started</strong> ${escHtml(formatFullDate(event.started_on))} &middot; ${finished}</div>`;
+    return `
+      <div class="read-history-item">
+        <span class="read-history-label">Started</span>
+        <span class="read-history-date">${escHtml(formatFullDate(event.started_on))}</span>
+        <span class="read-history-separator">&rarr;</span>
+        ${finished}
+      </div>
+    `;
   }).join('');
   document.getElementById('read-history-section').style.display = '';
 }

--- a/site/edit.html
+++ b/site/edit.html
@@ -484,6 +484,60 @@
       font-size: 0.92rem;
     }
 
+    .read-history-card {
+      margin-top: 12px;
+    }
+
+    .read-history-toolbar {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      gap: 12px;
+      margin-bottom: 10px;
+    }
+
+    .read-history-list {
+      display: grid;
+      gap: 10px;
+    }
+
+    .read-event-row {
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) minmax(0, 1fr) auto;
+      gap: 10px;
+      align-items: end;
+      padding: 10px;
+      border: 1px solid rgba(121, 94, 72, 0.11);
+      border-radius: 14px;
+      background: rgba(255,255,255,0.64);
+    }
+
+    .read-event-field {
+      display: grid;
+      gap: 5px;
+    }
+
+    .read-event-field span {
+      color: var(--muted);
+      font-size: 0.78rem;
+      font-weight: 700;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+    }
+
+    .read-event-remove {
+      align-self: end;
+      border: 1px solid rgba(156, 107, 103, 0.18);
+      border-radius: 999px;
+      background: var(--danger-soft);
+      color: var(--danger);
+      cursor: pointer;
+      font: inherit;
+      font-size: 0.86rem;
+      font-weight: 700;
+      padding: 9px 12px;
+    }
+
     .tag-shell {
       margin-top: 16px;
       display: grid;
@@ -884,6 +938,9 @@
       .field-grid.three-col {
         grid-template-columns: 1fr;
       }
+      .read-event-row {
+        grid-template-columns: 1fr;
+      }
       .danger-row,
       .sticky-bar,
       .review-head,
@@ -1004,14 +1061,21 @@
               <option value="5">5 stars</option>
             </select>
           </label>
-          <label class="field-card" id="date-read-card">
-            <span class="field-label">Date Read</span>
-            <input type="date" id="date_read" name="date_read">
-          </label>
         </div>
 
         <div class="priority-note hidden" id="read-priority-note">
-          Because this book is on <strong>Read</strong>, rating and finished date are highlighted as the most visible metadata on the public side.
+          Because this book is on <strong>Read</strong>, rating and read history are highlighted as the most visible metadata on the public side.
+        </div>
+
+        <div class="field-card read-history-card" id="read-history-card">
+          <div class="read-history-toolbar">
+            <div>
+              <span class="field-label">Read History</span>
+              <p class="field-help">Finish date is required for each completed read. Start date is optional.</p>
+            </div>
+            <button type="button" class="ghost-btn small" id="add-read-event-btn">Add read period</button>
+          </div>
+          <div class="read-history-list" id="read-history-list"></div>
         </div>
 
         <div class="tag-shell">
@@ -1249,6 +1313,71 @@
       return d.toLocaleDateString('en-US', options);
     }
 
+    function latestFinishedOn(events) {
+      return (events || [])
+        .map(event => event.finished_on || '')
+        .filter(Boolean)
+        .sort()
+        .pop() || '';
+    }
+
+    function readEventsFromForm({ validate = false } = {}) {
+      const rows = Array.from(document.querySelectorAll('.read-event-row'));
+      const events = [];
+      rows.forEach((row, index) => {
+        const startedOn = row.querySelector('[data-read-started]').value;
+        const finishedOn = row.querySelector('[data-read-finished]').value;
+        if (!startedOn && !finishedOn) return;
+        if (validate && !finishedOn) {
+          throw new Error(`Read period ${index + 1} needs a finish date.`);
+        }
+        if (validate && startedOn && finishedOn && startedOn > finishedOn) {
+          throw new Error(`Read period ${index + 1} starts after it finishes.`);
+        }
+        events.push({ started_on: startedOn || null, finished_on: finishedOn || '' });
+      });
+      return events;
+    }
+
+    function readEventsForDisplay() {
+      try {
+        return readEventsFromForm({ validate: false });
+      } catch (_) {
+        return [];
+      }
+    }
+
+    function renderReadEvents(events = []) {
+      const list = document.getElementById('read-history-list');
+      const normalized = events.length
+        ? events
+        : [{ started_on: '', finished_on: '' }];
+      list.innerHTML = normalized.map(event => `
+        <div class="read-event-row">
+          <label class="read-event-field">
+            <span>Start</span>
+            <input type="date" data-read-started value="${escAttr(event.started_on || '')}">
+          </label>
+          <label class="read-event-field">
+            <span>Finish *</span>
+            <input type="date" data-read-finished value="${escAttr(event.finished_on || '')}">
+          </label>
+          <button type="button" class="read-event-remove" data-remove-read-event>Remove</button>
+        </div>
+      `).join('');
+    }
+
+    function initialReadEvents(book) {
+      const events = Array.isArray(book.read_events) ? book.read_events : [];
+      if (events.length) {
+        return events.map(event => ({
+          started_on: event.started_on || '',
+          finished_on: event.finished_on || '',
+        }));
+      }
+      return book.date_read ? [{ started_on: '', finished_on: book.date_read }] : [];
+    }
+
     function coverSrcFromState(state) {
       if (state.cover_url) return state.cover_url;
       if (state.isbn13) return `https://covers.openlibrary.org/b/isbn/${encodeURIComponent(state.isbn13)}-L.jpg?default=false`;
@@ -1275,7 +1404,7 @@
         my_rating: document.getElementById('my_rating').value,
         isbn13: document.getElementById('isbn13').value,
         pages: document.getElementById('pages').value,
-        date_read: document.getElementById('date_read').value,
+        read_events: readEventsForDisplay(),
         date_added: document.getElementById('date_added').value,
         cover_url: document.getElementById('cover_url').value,
         my_review: document.getElementById('my_review').value,
@@ -1293,7 +1422,7 @@
         tags: dedupeTags(tagState.selected, true),
         isbn13: values.isbn13.trim(),
         pages: values.pages.trim(),
-        date_read: values.date_read,
+        read_events: values.read_events,
         date_added: values.date_added,
         cover_url: values.cover_url.trim(),
         my_review: values.my_review,
@@ -1337,7 +1466,7 @@
             my_rating: String(currentBook?.my_rating || 0),
             isbn13: currentBook?.isbn13 || '',
             pages: currentBook?.pages || '',
-            date_read: currentBook?.date_read || '',
+            read_events: initialReadEvents(currentBook || {}),
             cover_url: currentBook?.cover_url || '',
           }
         : getFormValues();
@@ -1356,7 +1485,8 @@
           : `<span class="meta-pill">${escHtml(ratingLabel(rating))}</span>`
       );
 
-      if (values.date_read) summaryParts.push(`<span class="meta-pill">Finished ${escHtml(formatDate(values.date_read))}</span>`);
+      const latestFinished = latestFinishedOn(values.read_events);
+      if (latestFinished) summaryParts.push(`<span class="meta-pill">Finished ${escHtml(formatDate(latestFinished))}</span>`);
       if (values.pages) summaryParts.push(`<span class="meta-pill">${escHtml(String(values.pages))} pages</span>`);
       if (currentBook && typeof currentBook.note_count === 'number') {
         summaryParts.push(`<span class="meta-pill">${currentBook.note_count} note${currentBook.note_count === 1 ? '' : 's'}</span>`);
@@ -1569,7 +1699,7 @@
     function updateShelfPriority() {
       const isRead = document.getElementById('exclusive_shelf').value === 'read';
       document.getElementById('rating-card').classList.toggle('priority', isRead);
-      document.getElementById('date-read-card').classList.toggle('priority', isRead);
+      document.getElementById('read-history-card').classList.toggle('priority', isRead);
       document.getElementById('read-priority-note').classList.toggle('hidden', !isRead);
     }
 
@@ -1586,11 +1716,11 @@
       document.getElementById('my_rating').value = String(book.my_rating || 0);
       document.getElementById('isbn13').value = book.isbn13 || '';
       document.getElementById('pages').value = book.pages || '';
-      document.getElementById('date_read').value = book.date_read || '';
       document.getElementById('date_added').value = book.date_added || '';
       document.getElementById('cover_url').value = book.cover_url || '';
       document.getElementById('my_review').value = book.my_review || '';
       document.getElementById('google_books_id').value = book.google_books_id || '';
+      renderReadEvents(initialReadEvents(book));
       setSelectedTags(book.shelves || []);
       updateReviewStats();
       updateShelfPriority();
@@ -1621,7 +1751,7 @@
         shelves: buildSubmittedShelves(values.exclusive_shelf),
         isbn13: values.isbn13.trim() || null,
         pages: values.pages.trim() ? Number(values.pages) : null,
-        date_read: values.date_read || null,
+        read_events: readEventsFromForm({ validate: true }),
         date_added: dateAdded,
         cover_url: values.cover_url.trim() || null,
         my_review: values.my_review.trim() ? values.my_review : null,
@@ -1655,7 +1785,13 @@
         return;
       }
 
-      const body = buildRequestBody();
+      let body;
+      try {
+        body = buildRequestBody();
+      } catch (err) {
+        setMessage(err.message, 'error');
+        return;
+      }
       if (!body.title || !body.author) {
         setMessage('Title and author are required.', 'error');
         return;
@@ -1723,6 +1859,25 @@
       renderTagSuggestions();
     });
     document.getElementById('details-panel').addEventListener('toggle', updateDetailsSummary);
+
+    document.getElementById('add-read-event-btn').addEventListener('click', () => {
+      const events = readEventsFromForm({ validate: false });
+      events.push({ started_on: '', finished_on: '' });
+      renderReadEvents(events);
+      renderHero();
+      updateDirtyState();
+    });
+
+    document.getElementById('read-history-list').addEventListener('click', e => {
+      const btn = e.target.closest('[data-remove-read-event]');
+      if (!btn) return;
+      btn.closest('.read-event-row').remove();
+      if (!document.querySelectorAll('.read-event-row').length) {
+        renderReadEvents([]);
+      }
+      renderHero();
+      updateDirtyState();
+    });
 
     document.getElementById('add-tag-btn').addEventListener('click', () => {
       addTag(document.getElementById('tag-input').value);

--- a/site/index.html
+++ b/site/index.html
@@ -2260,6 +2260,13 @@ function formatDate(d) {
   return date.toLocaleDateString('en-US', { month: 'short', year: 'numeric' });
 }
 
+function formatFullDate(d) {
+  if (!d) return '';
+  const date = new Date(`${d}T00:00:00`);
+  if (Number.isNaN(date.getTime())) return d;
+  return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+}
+
 function formatLongDate(d) {
   if (!d) return '';
   const date = new Date(d);
@@ -3645,12 +3652,26 @@ function formatWeekRange(wk) {
   return `${monStr} – ${sunStr}`;
 }
 
+function readEventEntries(book) {
+  const events = Array.isArray(book.read_events) ? book.read_events : [];
+  const finishedEvents = events.filter(event => event && event.finished_on);
+  if (!finishedEvents.length && book.date_read) {
+    finishedEvents.push({ id: null, started_on: '', finished_on: book.date_read });
+  }
+  return finishedEvents.map(event => ({
+    ...book,
+    date_read: event.finished_on,
+    read_event: event,
+  }));
+}
+
 function buildWeeksData(books) {
   const withDate = [];
   let missingCount = 0;
   for (const b of books) {
-    if (b.date_read) {
-      withDate.push(b);
+    const entries = readEventEntries(b);
+    if (entries.length) {
+      withDate.push(...entries);
     } else {
       missingCount++;
     }
@@ -3868,6 +3889,7 @@ function showWeeksTooltip(target, wkKey) {
     html += `<div class="weeks-tooltip-book">
       <div class="weeks-tooltip-title">${escHtml(b.title)}</div>
       <div class="weeks-tooltip-author">${escHtml(b.author)}${starStr ? ' · ' + starStr : ''}</div>
+      <div class="weeks-tooltip-tags">Finished ${escHtml(formatFullDate(b.date_read))}</div>
       ${tags ? `<div class="weeks-tooltip-tags">${escHtml(tags)}</div>` : ''}
     </div>`;
   }

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -31,6 +31,7 @@ from db import (
     insert_book,
     insert_book_suggestion,
     list_activity_rows,
+    replace_read_events,
     run_migrations,
     set_llm_cache_value,
     update_book,
@@ -264,20 +265,21 @@ class DbSchemaTests(unittest.TestCase):
         self.assertIn("activity_log", tables)
         self.assertIn("book_suggestions", tables)
         self.assertIn("capture_events", tables)
+        self.assertIn("book_read_events", tables)
         self.assertIn("schema_version", tables)
         conn.close()
 
-    def test_schema_version_is_8(self):
+    def test_schema_version_is_9(self):
         conn = get_connection(self.db_path)
         run_migrations(conn)
-        self.assertEqual(get_schema_version(conn), 8)
+        self.assertEqual(get_schema_version(conn), 9)
         conn.close()
 
     def test_migrations_are_idempotent(self):
         conn = get_connection(self.db_path)
         run_migrations(conn)
         run_migrations(conn)
-        self.assertEqual(get_schema_version(conn), 8)
+        self.assertEqual(get_schema_version(conn), 9)
         conn.close()
 
     def test_existing_notes_table_upgrades_cleanly(self):
@@ -330,17 +332,56 @@ class DbSchemaTests(unittest.TestCase):
             for row in conn.execute("PRAGMA table_info(book_suggestions)").fetchall()
         }
 
-        self.assertEqual(applied, 7)
-        self.assertEqual(get_schema_version(conn), 8)
+        self.assertEqual(applied, 8)
+        self.assertEqual(get_schema_version(conn), 9)
         self.assertIn("notes", tables)
         self.assertIn("activity_log", tables)
         self.assertIn("book_suggestions", tables)
         self.assertIn("capture_events", tables)
+        self.assertIn("book_read_events", tables)
         self.assertIn("connected_label", note_columns)
         self.assertIn("connected_url", note_columns)
         self.assertIn("client_ip_hash", suggestion_columns)
         self.assertIn("user_agent", suggestion_columns)
         self.assertIn("content_fingerprint", suggestion_columns)
+        conn.close()
+
+    def test_read_events_migration_backfills_existing_date_read(self):
+        conn = get_connection(self.db_path)
+        db_module._migration_v1(conn)
+        conn.execute(
+            """INSERT INTO books
+               (title, author, date_read, date_added, exclusive_shelf)
+               VALUES (?, ?, ?, ?, ?)""",
+            ("Reread Book", "Author", "2020-05-01", "2020-04-01", "read"),
+        )
+        conn.execute(
+            """INSERT INTO books
+               (title, author, date_read, date_added, exclusive_shelf)
+               VALUES (?, ?, ?, ?, ?)""",
+            ("No Date", "Author", None, "2020-04-01", "read"),
+        )
+        conn.execute(
+            """INSERT INTO books
+               (title, author, date_read, date_added, exclusive_shelf)
+               VALUES (?, ?, ?, ?, ?)""",
+            ("Blank Date", "Author", "", "2020-04-01", "read"),
+        )
+        conn.execute(
+            """CREATE TABLE IF NOT EXISTS schema_version (
+                version INTEGER PRIMARY KEY,
+                applied_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+            )"""
+        )
+        conn.execute("INSERT INTO schema_version (version) VALUES (1)")
+        conn.commit()
+
+        run_migrations(conn)
+        rows = conn.execute(
+            "SELECT book_id, finished_on FROM book_read_events ORDER BY book_id"
+        ).fetchall()
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["finished_on"], "2020-05-01")
         conn.close()
 
     def test_insert_and_list_activity_rows(self):
@@ -521,6 +562,8 @@ class BookshelfDBTests(unittest.TestCase):
         self.assertEqual(stats["total_to_read"], 1)
         self.assertEqual(stats["currently_reading_count"], 1)
         self.assertEqual(stats["avg_my_rating"], 4.0)
+        self.assertEqual(stats["read_completions"], 2)
+        self.assertEqual(stats["read_completions_this_year"], 1)
 
     def test_books_read_sorted_by_date_read_desc(self):
         books = self.db_store.books()
@@ -545,8 +588,35 @@ class BookshelfDBTests(unittest.TestCase):
         # Empty strings not None
         self.assertIsInstance(book.get("isbn13"), str)
         self.assertIsInstance(book.get("date_read"), str)
+        self.assertIsInstance(book.get("read_events"), list)
         # Shelves should be a list
         self.assertIsInstance(book["shelves"], list)
+
+    def test_read_events_are_returned_and_date_read_is_latest_finish(self):
+        conn = get_connection(self.db_path)
+        replace_read_events(conn, 2, [
+            {"started_on": "2021-01-01", "finished_on": "2021-02-01"},
+            {"started_on": "2026-02-01", "finished_on": "2026-03-05"},
+        ])
+        conn.commit()
+        conn.close()
+
+        books = self.db_store.books()
+        read = books["books"]["read"]
+        self.assertEqual(read[0]["title"], "1984")
+        self.assertEqual(read[0]["date_read"], "2026-03-05")
+        self.assertEqual([event["finished_on"] for event in read[0]["read_events"]], [
+            "2026-03-05",
+            "2021-02-01",
+        ])
+
+    def test_replace_read_events_validates_finish_and_start_order(self):
+        conn = get_connection(self.db_path)
+        with self.assertRaises(ValueError):
+            replace_read_events(conn, 1, [{"started_on": "2026-01-01"}])
+        with self.assertRaises(ValueError):
+            replace_read_events(conn, 1, [{"started_on": "2026-02-01", "finished_on": "2026-01-01"}])
+        conn.close()
 
     def test_book_empty_review_is_empty_string(self):
         books = self.db_store.books()
@@ -727,6 +797,7 @@ class ApiSqliteTests(unittest.TestCase):
         data = resp.json()
         self.assertEqual(len(data["books"]["read"]), 3)
         self.assertEqual(data["books"]["read"][0]["title"], "Dune")
+        self.assertEqual(data["books"]["read"][0]["read_events"][0]["finished_on"], "2026-01-15")
 
     def test_single_book_endpoint(self):
         resp = self.client.get("/api/books/1")
@@ -735,6 +806,7 @@ class ApiSqliteTests(unittest.TestCase):
         self.assertEqual(data["title"], "Dune")
         self.assertEqual(data["author"], "Frank Herbert")
         self.assertEqual(data["note_count"], 0)
+        self.assertEqual(data["read_events"][0]["finished_on"], "2026-01-15")
 
     def test_single_book_endpoint_not_found(self):
         resp = self.client.get("/api/books/99999")
@@ -853,6 +925,81 @@ class ApiSqliteTests(unittest.TestCase):
         )
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(resp.json()["title"], "New Title")
+
+    def test_create_book_accepts_read_events_and_sets_latest_date_read(self):
+        resp = self.client.post(
+            "/api/books",
+            json={
+                "title": "Reread Book",
+                "author": "Author",
+                "exclusive_shelf": "read",
+                "read_events": [
+                    {"started_on": "2020-01-01", "finished_on": "2020-02-01"},
+                    {"started_on": "2026-01-01", "finished_on": "2026-02-01"},
+                ],
+            },
+            headers=TEST_AUTH_HEADER,
+        )
+        self.assertEqual(resp.status_code, 201)
+        data = resp.json()
+        self.assertEqual(data["date_read"], "2026-02-01")
+        self.assertEqual([event["finished_on"] for event in data["read_events"]], [
+            "2026-02-01",
+            "2020-02-01",
+        ])
+
+    def test_update_book_replaces_read_events_and_resyncs_latest_date(self):
+        resp = self.client.post(
+            "/api/books",
+            json={
+                "title": "Eventful Book",
+                "author": "Author",
+                "exclusive_shelf": "read",
+                "date_read": "2020-01-01",
+            },
+            headers=TEST_AUTH_HEADER,
+        )
+        book_id = resp.json()["id"]
+
+        resp = self.client.put(
+            f"/api/books/{book_id}",
+            json={
+                "read_events": [
+                    {"started_on": "2025-12-01", "finished_on": "2026-01-15"},
+                    {"started_on": None, "finished_on": "2021-05-01"},
+                ],
+            },
+            headers=TEST_AUTH_HEADER,
+        )
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertEqual(data["date_read"], "2026-01-15")
+        self.assertEqual([event["finished_on"] for event in data["read_events"]], [
+            "2026-01-15",
+            "2021-05-01",
+        ])
+
+    def test_update_book_rejects_invalid_read_events(self):
+        resp = self.client.post(
+            "/api/books",
+            json={"title": "Bad Events", "author": "Author", "exclusive_shelf": "read"},
+            headers=TEST_AUTH_HEADER,
+        )
+        book_id = resp.json()["id"]
+
+        missing_finish = self.client.put(
+            f"/api/books/{book_id}",
+            json={"read_events": [{"started_on": "2026-01-01"}]},
+            headers=TEST_AUTH_HEADER,
+        )
+        self.assertEqual(missing_finish.status_code, 422)
+
+        inverted = self.client.put(
+            f"/api/books/{book_id}",
+            json={"read_events": [{"started_on": "2026-02-01", "finished_on": "2026-01-01"}]},
+            headers=TEST_AUTH_HEADER,
+        )
+        self.assertEqual(inverted.status_code, 422)
 
     def test_update_book_logs_when_entering_currently_reading_or_read(self):
         resp = self.client.post(


### PR DESCRIPTION
Closes #46

## Summary
- Add first-class read history with `book_read_events`; existing `books.date_read` values are backfilled as completed read events.
- Add migration v10 so `finished_on` can be nullable for in-progress read periods.
- Keep `books.date_read` as the latest completed finish date while exposing full `read_events` in API payloads.
- Add read-history editing, public display, and Reading Life grid support for multiple completions of the same book.
- Let currently-reading books store a start date without a finish date, including from the add-book form.
- Preserve unique-book stats and add completion-count stats.

## Validation
- `.venv/bin/python -m unittest discover -s tests`
- `.venv/bin/python -m py_compile db.py bookshelf_data.py api/main.py scripts/migrate_json_to_sqlite.py`
- Inline script parse check for `site/index.html`, `site/book.html`, `site/edit.html`, and `site/add.html`
- `git diff --check`