### PR TITLE
[codex] Allow in-progress read periods

### DIFF
--- a/db.py
+++ b/db.py
@@ -273,6 +273,65 @@ def _migration_v9(conn: sqlite3.Connection) -> None:
     )
 
 
+_BOOK_READ_EVENTS_SCHEMA_V10 = """
+CREATE TABLE IF NOT EXISTS book_read_events (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    book_id INTEGER NOT NULL,
+    started_on TEXT,
+    finished_on TEXT,
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+    updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+    FOREIGN KEY (book_id) REFERENCES books(id) ON DELETE CASCADE,
+    CHECK (
+        finished_on IS NULL
+        OR finished_on = ''
+        OR started_on IS NULL
+        OR started_on = ''
+        OR started_on <= finished_on
+    )
+);
+
+CREATE INDEX IF NOT EXISTS idx_book_read_events_book_finished
+    ON book_read_events(book_id, finished_on DESC, id DESC);
+CREATE INDEX IF NOT EXISTS idx_book_read_events_finished
+    ON book_read_events(finished_on DESC);
+"""
+
+
+def _read_events_finished_on_is_required(conn: sqlite3.Connection) -> bool:
+    row = next(
+        (
+            column
+            for column in conn.execute("PRAGMA table_info(book_read_events)").fetchall()
+            if column["name"] == "finished_on"
+        ),
+        None,
+    )
+    return bool(row and row["notnull"])
+
+
+def _migration_v10(conn: sqlite3.Connection) -> None:
+    if not _read_events_finished_on_is_required(conn):
+        conn.executescript(_BOOK_READ_EVENTS_SCHEMA_V10)
+        return
+
+    conn.executescript(
+        """
+        DROP INDEX IF EXISTS idx_book_read_events_book_finished;
+        DROP INDEX IF EXISTS idx_book_read_events_finished;
+        ALTER TABLE book_read_events RENAME TO book_read_events_v9;
+        """
+    )
+    conn.executescript(_BOOK_READ_EVENTS_SCHEMA_V10)
+    conn.execute(
+        """INSERT INTO book_read_events
+           (id, book_id, started_on, finished_on, created_at, updated_at)
+           SELECT id, book_id, started_on, finished_on, created_at, updated_at
+           FROM book_read_events_v9"""
+    )
+    conn.execute("DROP TABLE book_read_events_v9")
+
+
 MIGRATIONS: list[tuple[int, Callable[[sqlite3.Connection], None]]] = [
     (1, _migration_v1),
     (2, _migration_v2),
@@ -283,6 +342,7 @@ MIGRATIONS: list[tuple[int, Callable[[sqlite3.Connection], None]]] = [
     (7, _migration_v7),
     (8, _migration_v8),
     (9, _migration_v9),
+    (10, _migration_v10),
 ]
 
 
@@ -396,8 +456,9 @@ def normalize_read_events(raw_events: Any) -> list[dict[str, str | None]]:
         finished_on = _normalize_date_value(
             raw_event.get("finished_on"),
             f"read_events[{idx}].finished_on",
-            required=True,
         )
+        if not started_on and not finished_on:
+            continue
         if started_on and finished_on and started_on > finished_on:
             raise ValueError(f"read_events[{idx}].started_on cannot be after finished_on.")
         normalized.append({"started_on": started_on, "finished_on": finished_on})
@@ -410,7 +471,7 @@ def list_read_events(conn: sqlite3.Connection, book_id: int) -> list[dict[str, A
         """SELECT id, book_id, started_on, finished_on, created_at, updated_at
            FROM book_read_events
            WHERE book_id = ?
-           ORDER BY finished_on DESC, id DESC""",
+           ORDER BY COALESCE(NULLIF(finished_on, ''), NULLIF(started_on, '')) DESC, id DESC""",
         (book_id,),
     ).fetchall()
     events: list[dict[str, Any]] = []
@@ -424,7 +485,7 @@ def list_read_events(conn: sqlite3.Connection, book_id: int) -> list[dict[str, A
 
 def sync_book_latest_read_date(conn: sqlite3.Connection, book_id: int) -> None:
     row = conn.execute(
-        "SELECT MAX(finished_on) AS latest FROM book_read_events WHERE book_id = ?",
+        "SELECT MAX(NULLIF(finished_on, '')) AS latest FROM book_read_events WHERE book_id = ?",
         (book_id,),
     ).fetchone()
     latest = row["latest"] if row else None

--- a/site/add.html
+++ b/site/add.html
@@ -196,9 +196,15 @@
       </div>
       <div class="form-row">
         <div class="form-group">
-          <label for="date_read">Date Read</label>
+          <label for="date_started">Start Date</label>
+          <input type="date" id="date_started" name="date_started">
+        </div>
+        <div class="form-group">
+          <label for="date_read">Finish Date</label>
           <input type="date" id="date_read" name="date_read">
         </div>
+      </div>
+      <div class="form-row">
         <div class="form-group">
           <label for="date_added">Date Added</label>
           <input type="date" id="date_added" name="date_added">
@@ -443,15 +449,22 @@ document.getElementById('add-form').addEventListener('submit', async e => {
   // Optional expanded fields
   const isbn13 = document.getElementById('isbn13').value.trim();
   const pages = document.getElementById('pages').value.trim();
+  const date_started = document.getElementById('date_started').value;
   const date_read = document.getElementById('date_read').value;
   const date_added = document.getElementById('date_added').value;
   const cover_url = document.getElementById('cover_url').value.trim();
   const my_review = document.getElementById('my_review').value.trim();
   const google_books_id = document.getElementById('google_books_id').value.trim();
 
+  if (date_started && date_read && date_started > date_read) {
+    btn.disabled = false;
+    btn.textContent = 'Add Book';
+    return showMessage('Start date cannot be after finish date.', 'error');
+  }
+
   if (isbn13) body.isbn13 = isbn13;
   if (pages) body.pages = parseInt(pages);
-  if (date_read) body.read_events = [{ started_on: null, finished_on: date_read }];
+  if (date_started || date_read) body.read_events = [{ started_on: date_started || null, finished_on: date_read || null }];
   if (date_added) body.date_added = date_added;
   if (cover_url) body.cover_url = cover_url;
   if (my_review) body.my_review = my_review;

--- a/site/book.html
+++ b/site/book.html
@@ -545,23 +545,35 @@ function renderReview(book) {
 
 function renderReadHistory(book) {
   const events = Array.isArray(book.read_events) ? book.read_events : [];
-  const finishedEvents = events.filter(event => event && event.finished_on);
-  if (!finishedEvents.length) return;
+  const historyEvents = events.filter(event => event && (event.started_on || event.finished_on));
+  if (!historyEvents.length) return;
 
-  document.getElementById('read-history-list').innerHTML = finishedEvents.map(event => {
-    const finished = `
-      <span class="read-history-label">Finished</span>
-      <span class="read-history-date">${escHtml(formatFullDate(event.finished_on))}</span>
-    `;
+  document.getElementById('read-history-list').innerHTML = historyEvents.map(event => {
+    if (event.started_on && !event.finished_on) {
+      return `
+        <div class="read-history-item">
+          <span class="read-history-label">Started</span>
+          <span class="read-history-date">${escHtml(formatFullDate(event.started_on))}</span>
+          <span class="read-history-separator">&rarr;</span>
+          <span class="read-history-label">In progress</span>
+        </div>
+      `;
+    }
     if (!event.started_on) {
-      return `<div class="read-history-item">${finished}</div>`;
+      return `
+        <div class="read-history-item">
+          <span class="read-history-label">Finished</span>
+          <span class="read-history-date">${escHtml(formatFullDate(event.finished_on))}</span>
+        </div>
+      `;
     }
     return `
       <div class="read-history-item">
         <span class="read-history-label">Started</span>
         <span class="read-history-date">${escHtml(formatFullDate(event.started_on))}</span>
         <span class="read-history-separator">&rarr;</span>
-        ${finished}
+        <span class="read-history-label">Finished</span>
+        <span class="read-history-date">${escHtml(formatFullDate(event.finished_on))}</span>
       </div>
     `;
   }).join('');

--- a/site/edit.html
+++ b/site/edit.html
@@ -1071,7 +1071,7 @@
           <div class="read-history-toolbar">
             <div>
               <span class="field-label">Read History</span>
-              <p class="field-help">Finish date is required for each completed read. Start date is optional.</p>
+              <p class="field-help">Leave Finish blank while a read is in progress. Completed reads still use the latest finish date.</p>
             </div>
             <button type="button" class="ghost-btn small" id="add-read-event-btn">Add read period</button>
           </div>
@@ -1328,13 +1328,10 @@
         const startedOn = row.querySelector('[data-read-started]').value;
         const finishedOn = row.querySelector('[data-read-finished]').value;
         if (!startedOn && !finishedOn) return;
-        if (validate && !finishedOn) {
-          throw new Error(`Read period ${index + 1} needs a finish date.`);
-        }
         if (validate && startedOn && finishedOn && startedOn > finishedOn) {
           throw new Error(`Read period ${index + 1} starts after it finishes.`);
         }
-        events.push({ started_on: startedOn || null, finished_on: finishedOn || '' });
+        events.push({ started_on: startedOn || null, finished_on: finishedOn || null });
       });
       return events;
     }
@@ -1359,7 +1356,7 @@
             <input type="date" data-read-started value="${escAttr(event.started_on || '')}">
           </label>
           <label class="read-event-field">
-            <span>Finish *</span>
+            <span>Finish</span>
             <input type="date" data-read-finished value="${escAttr(event.finished_on || '')}">
           </label>
           <button type="button" class="read-event-remove" data-remove-read-event>Remove</button>

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -267,19 +267,24 @@ class DbSchemaTests(unittest.TestCase):
         self.assertIn("capture_events", tables)
         self.assertIn("book_read_events", tables)
         self.assertIn("schema_version", tables)
+        read_event_columns = {
+            row["name"]: row
+            for row in conn.execute("PRAGMA table_info(book_read_events)").fetchall()
+        }
+        self.assertEqual(read_event_columns["finished_on"]["notnull"], 0)
         conn.close()
 
-    def test_schema_version_is_9(self):
+    def test_schema_version_is_10(self):
         conn = get_connection(self.db_path)
         run_migrations(conn)
-        self.assertEqual(get_schema_version(conn), 9)
+        self.assertEqual(get_schema_version(conn), 10)
         conn.close()
 
     def test_migrations_are_idempotent(self):
         conn = get_connection(self.db_path)
         run_migrations(conn)
         run_migrations(conn)
-        self.assertEqual(get_schema_version(conn), 9)
+        self.assertEqual(get_schema_version(conn), 10)
         conn.close()
 
     def test_existing_notes_table_upgrades_cleanly(self):
@@ -332,8 +337,8 @@ class DbSchemaTests(unittest.TestCase):
             for row in conn.execute("PRAGMA table_info(book_suggestions)").fetchall()
         }
 
-        self.assertEqual(applied, 8)
-        self.assertEqual(get_schema_version(conn), 9)
+        self.assertEqual(applied, 9)
+        self.assertEqual(get_schema_version(conn), 10)
         self.assertIn("notes", tables)
         self.assertIn("activity_log", tables)
         self.assertIn("book_suggestions", tables)
@@ -382,6 +387,45 @@ class DbSchemaTests(unittest.TestCase):
         ).fetchall()
         self.assertEqual(len(rows), 1)
         self.assertEqual(rows[0]["finished_on"], "2020-05-01")
+        conn.close()
+
+    def test_read_events_finished_on_is_nullable_after_v10_migration(self):
+        conn = get_connection(self.db_path)
+        db_module._migration_v1(conn)
+        book_id = insert_book(conn, {
+            "title": "Started Book",
+            "author": "Author",
+            "date_added": "2026-04-16",
+            "exclusive_shelf": "currently_reading",
+        })
+        db_module._migration_v9(conn)
+        conn.execute(
+            """CREATE TABLE IF NOT EXISTS schema_version (
+                version INTEGER PRIMARY KEY,
+                applied_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+            )"""
+        )
+        conn.execute("INSERT INTO schema_version (version) VALUES (9)")
+        conn.commit()
+
+        run_migrations(conn)
+        columns = {
+            row["name"]: row
+            for row in conn.execute("PRAGMA table_info(book_read_events)").fetchall()
+        }
+        self.assertEqual(get_schema_version(conn), 10)
+        self.assertEqual(columns["finished_on"]["notnull"], 0)
+
+        replace_read_events(conn, book_id, [{"started_on": "2026-04-16"}])
+        conn.commit()
+        row = conn.execute(
+            "SELECT started_on, finished_on FROM book_read_events WHERE book_id = ?",
+            (book_id,),
+        ).fetchone()
+        book = conn.execute("SELECT date_read FROM books WHERE id = ?", (book_id,)).fetchone()
+        self.assertEqual(row["started_on"], "2026-04-16")
+        self.assertIsNone(row["finished_on"])
+        self.assertIsNone(book["date_read"])
         conn.close()
 
     def test_insert_and_list_activity_rows(self):
@@ -610,10 +654,15 @@ class BookshelfDBTests(unittest.TestCase):
             "2021-02-01",
         ])
 
-    def test_replace_read_events_validates_finish_and_start_order(self):
+    def test_replace_read_events_allows_start_only_and_validates_start_order(self):
         conn = get_connection(self.db_path)
-        with self.assertRaises(ValueError):
-            replace_read_events(conn, 1, [{"started_on": "2026-01-01"}])
+        replace_read_events(conn, 1, [{"started_on": "2026-01-01"}])
+        row = conn.execute(
+            "SELECT started_on, finished_on FROM book_read_events WHERE book_id = ?",
+            (1,),
+        ).fetchone()
+        self.assertEqual(row["started_on"], "2026-01-01")
+        self.assertIsNone(row["finished_on"])
         with self.assertRaises(ValueError):
             replace_read_events(conn, 1, [{"started_on": "2026-02-01", "finished_on": "2026-01-01"}])
         conn.close()
@@ -948,6 +997,25 @@ class ApiSqliteTests(unittest.TestCase):
             "2020-02-01",
         ])
 
+    def test_create_currently_reading_accepts_start_only_read_event(self):
+        resp = self.client.post(
+            "/api/books",
+            json={
+                "title": "Just Started",
+                "author": "Author",
+                "exclusive_shelf": "currently_reading",
+                "read_events": [
+                    {"started_on": "2026-04-16"},
+                ],
+            },
+            headers=TEST_AUTH_HEADER,
+        )
+        self.assertEqual(resp.status_code, 201)
+        data = resp.json()
+        self.assertEqual(data["date_read"], "")
+        self.assertEqual(data["read_events"][0]["started_on"], "2026-04-16")
+        self.assertEqual(data["read_events"][0]["finished_on"], "")
+
     def test_update_book_replaces_read_events_and_resyncs_latest_date(self):
         resp = self.client.post(
             "/api/books",
@@ -979,6 +1047,29 @@ class ApiSqliteTests(unittest.TestCase):
             "2021-05-01",
         ])
 
+    def test_update_book_accepts_start_only_read_event_without_changing_date_read(self):
+        resp = self.client.post(
+            "/api/books",
+            json={
+                "title": "Started Again",
+                "author": "Author",
+                "exclusive_shelf": "currently_reading",
+            },
+            headers=TEST_AUTH_HEADER,
+        )
+        book_id = resp.json()["id"]
+
+        resp = self.client.put(
+            f"/api/books/{book_id}",
+            json={"read_events": [{"started_on": "2026-04-16"}]},
+            headers=TEST_AUTH_HEADER,
+        )
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertEqual(data["date_read"], "")
+        self.assertEqual(data["read_events"][0]["started_on"], "2026-04-16")
+        self.assertEqual(data["read_events"][0]["finished_on"], "")
+
     def test_update_book_rejects_invalid_read_events(self):
         resp = self.client.post(
             "/api/books",
@@ -986,13 +1077,6 @@ class ApiSqliteTests(unittest.TestCase):
             headers=TEST_AUTH_HEADER,
         )
         book_id = resp.json()["id"]
-
-        missing_finish = self.client.put(
-            f"/api/books/{book_id}",
-            json={"read_events": [{"started_on": "2026-01-01"}]},
-            headers=TEST_AUTH_HEADER,
-        )
-        self.assertEqual(missing_finish.status_code, 422)
 
         inverted = self.client.put(
             f"/api/books/{book_id}",


### PR DESCRIPTION
## Summary
- Add migration v10 to make `book_read_events.finished_on` nullable while preserving existing read history.
- Allow start-only read events through storage/API validation so currently-reading books can record a start date before completion.
- Update the edit and add-book forms to allow blank Finish dates, with validation only when both dates are present.
- Show start-only read periods publicly as in-progress while keeping Books Read and Reading Life based on completed finish dates.

## Validation
- `.venv/bin/python -m unittest discover -s tests`
- `.venv/bin/python -m py_compile db.py bookshelf_data.py api/main.py scripts/migrate_json_to_sqlite.py`
- Inline script parse check for `site/index.html`, `site/book.html`, `site/edit.html`, and `site/add.html`
- `git diff --check`