### PR TITLE
[codex] Bucket taste profile input

### DIFF
--- a/README.md
+++ b/README.md
@@ -493,6 +493,7 @@ make restart-staging-api
 - Anthropic powers one recommendation column and is the default taste profile provider
 - OpenAI powers one recommendation column and can also generate the taste profile with `--taste-profile-provider openai`
 - Gemini powers one recommendation column
+- the taste profile uses a bucketed snapshot: recent completed reads, currently-reading books with notes, older high-signal anchors, and a deterministic historical sample
 - partial refreshes are supported by provider
 - `LLM_DRY_RUN=true` writes placeholders instead of making live model calls
 

--- a/api/main.py
+++ b/api/main.py
@@ -223,7 +223,7 @@ async def _run_llm_regeneration(
     if taste_profile_provider and "taste_profile" in selected_targets:
         _llm_status["taste_profile_provider"] = taste_profile_provider
     try:
-        books_payload = store.books()
+        books_payload = store.books(include_notes=True)
         cache_payload = store.llm_cache()
 
         from scripts.generate_llm import generate_cache_payload, _save_llm_cache_to_db

--- a/bookshelf_data.py
+++ b/bookshelf_data.py
@@ -168,22 +168,50 @@ def compute_books_hash(books_payload: dict[str, Any] | list[dict[str, Any]]) -> 
     return hashlib.sha256(payload.encode("utf-8")).hexdigest()
 
 
-def _llm_input_hash_entry(book: dict[str, Any]) -> list[Any]:
+def _llm_note_hash_entry(note: dict[str, Any]) -> list[Any]:
     return [
+        int(note.get("id") or 0),
+        (note.get("note_type") or "").strip(),
+        (note.get("content") or "").strip(),
+        (note.get("page_or_location") or "").strip(),
+        (note.get("created_at") or "").strip(),
+    ]
+
+
+def _llm_input_hash_entry(book: dict[str, Any], shelf_key: str = "read") -> list[Any]:
+    return [
+        shelf_key,
         (book.get("title") or "").strip(),
         (book.get("author") or "").strip(),
         int(book.get("my_rating") or 0),
         (book.get("my_review") or book.get("review") or "").strip(),
+        (book.get("date_read") or "").strip(),
+        sorted(str(shelf).strip() for shelf in (book.get("shelves") or []) if str(shelf).strip()),
+        [_llm_note_hash_entry(note) for note in (book.get("notes") or []) if isinstance(note, dict)],
     ]
 
 
 def compute_llm_input_hash(books_payload: dict[str, Any] | list[dict[str, Any]]) -> str:
     if isinstance(books_payload, dict):
-        read_books = books_payload.get("books", {}).get("read", [])
+        books_by_shelf = books_payload.get("books", {})
+        current_books_with_notes = [
+            book
+            for book in books_by_shelf.get("currently_reading", [])
+            if any(
+                str(note.get("content") or "").strip()
+                for note in (book.get("notes") or [])
+                if isinstance(note, dict)
+            )
+        ]
+        fingerprint = sorted(
+            [_llm_input_hash_entry(book, "read") for book in books_by_shelf.get("read", [])]
+            + [
+                _llm_input_hash_entry(book, "currently_reading")
+                for book in current_books_with_notes
+            ]
+        )
     else:
-        read_books = books_payload
-
-    fingerprint = sorted(_llm_input_hash_entry(book) for book in read_books)
+        fingerprint = sorted(_llm_input_hash_entry(book, "read") for book in books_payload)
     payload = json.dumps(fingerprint, ensure_ascii=False, separators=(",", ":"))
     return hashlib.sha256(payload.encode("utf-8")).hexdigest()
 
@@ -314,7 +342,7 @@ class BookshelfStore:
         self.books_file = JsonFileCache(books_path, default_books_payload)
         self.llm_cache_file = JsonFileCache(llm_cache_path, default_llm_cache)
 
-    def books(self) -> dict[str, Any]:
+    def books(self, include_notes: bool = False) -> dict[str, Any]:
         payload = self.books_file.read()
         for shelf in payload.get("books", {}).values():
             if not isinstance(shelf, list):
@@ -413,7 +441,7 @@ class BookshelfDB:
 
         return d
 
-    def _get_books_by_shelf(self, shelf: str) -> list[dict[str, Any]]:
+    def _get_books_by_shelf(self, shelf: str, include_notes: bool = False) -> list[dict[str, Any]]:
         if shelf == "read":
             order = """
                 CASE WHEN date_read IS NOT NULL AND date_read != '' THEN 0 ELSE 1 END,
@@ -428,7 +456,53 @@ class BookshelfDB:
             f"SELECT * FROM books WHERE exclusive_shelf = ? ORDER BY {order}",
             (shelf,),
         ).fetchall()
-        return [self._row_to_book(row) for row in rows]
+        books = [self._row_to_book(row) for row in rows]
+        if include_notes:
+            self._attach_recent_notes(books)
+        return books
+
+    def _attach_recent_notes(self, books: list[dict[str, Any]], limit: int = 3) -> None:
+        book_ids = [int(book["id"]) for book in books if book.get("id")]
+        if not book_ids:
+            return
+
+        placeholders = ",".join("?" for _ in book_ids)
+        counts = {
+            int(row["source_id"]): int(row["count"])
+            for row in self.conn().execute(
+                f"""SELECT source_id, COUNT(*) AS count
+                    FROM notes
+                    WHERE source_type = 'book' AND source_id IN ({placeholders})
+                    GROUP BY source_id""",
+                book_ids,
+            ).fetchall()
+        }
+        notes_by_book: dict[int, list[dict[str, Any]]] = {book_id: [] for book_id in book_ids}
+        rows = self.conn().execute(
+            f"""SELECT id, source_id, note_type, content, page_or_location, created_at
+                FROM notes
+                WHERE source_type = 'book' AND source_id IN ({placeholders})
+                ORDER BY source_id, created_at DESC, id DESC""",
+            book_ids,
+        ).fetchall()
+        for row in rows:
+            book_id = int(row["source_id"])
+            if len(notes_by_book.get(book_id, [])) >= limit:
+                continue
+            notes_by_book.setdefault(book_id, []).append(
+                {
+                    "id": row["id"],
+                    "note_type": row["note_type"],
+                    "content": row["content"] or "",
+                    "page_or_location": row["page_or_location"] or "",
+                    "created_at": row["created_at"] or "",
+                }
+            )
+
+        for book in books:
+            book_id = int(book.get("id") or 0)
+            book["note_count"] = counts.get(book_id, 0)
+            book["notes"] = notes_by_book.get(book_id, [])
 
     def _compute_stats(self, read_books: list[dict[str, Any]],
                        to_read_count: int,
@@ -467,10 +541,10 @@ class BookshelfDB:
             "currently_reading_count": currently_reading_count,
         }
 
-    def books(self) -> dict[str, Any]:
-        read = self._get_books_by_shelf("read")
-        currently_reading = self._get_books_by_shelf("currently_reading")
-        to_read = self._get_books_by_shelf("to_read")
+    def books(self, include_notes: bool = False) -> dict[str, Any]:
+        read = self._get_books_by_shelf("read", include_notes=include_notes)
+        currently_reading = self._get_books_by_shelf("currently_reading", include_notes=include_notes)
+        to_read = self._get_books_by_shelf("to_read", include_notes=include_notes)
         stats = self._compute_stats(read, len(to_read), len(currently_reading))
 
         # Use the most recent updated_at as generated_at

--- a/scripts/generate_llm.py
+++ b/scripts/generate_llm.py
@@ -223,6 +223,7 @@ def build_mock_taste_profile(
         "model": model_name,
         "provider": provider,
         "summary": "[DRY RUN] Mock taste profile",
+        "current_drift": "[DRY RUN] Mock current drift",
         "traits": [
             {
                 "label": "Mock Trait",
@@ -252,23 +253,178 @@ def build_mock_recommendations(model_name: str, prefix: str) -> dict[str, Any]:
         "reasoning": f"[DRY RUN] Placeholder recommendation strategy from {prefix}.",
     }
 
-def build_library_snapshot(books_payload: dict[str, Any]) -> dict[str, Any]:
-    books = books_payload.get("books", {})
+RECENT_READ_LIMIT = 50
+CURRENT_READING_NOTE_LIMIT = 2
+HISTORICAL_ANCHOR_LIMIT = 25
+HISTORICAL_SAMPLE_LIMIT = 50
 
-    def _read_entry(book: dict[str, Any]) -> dict[str, Any]:
-        entry = {
-            "title": book.get("title"),
-            "author": book.get("author"),
-            "my_rating": book.get("my_rating"),
-            "my_review": book.get("my_review"),
-            "shelves": book.get("shelves", []),
-            "date_read": book.get("date_read"),
-        }
-        return entry
+
+def _book_identity(book: dict[str, Any]) -> tuple[str, str]:
+    return normalize_book_key(book.get("title", ""), book.get("author", ""))
+
+
+def _book_entry(
+    book: dict[str, Any],
+    *,
+    include_notes: bool = False,
+    notes_limit: int = 0,
+    extra: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    entry = {
+        "title": book.get("title"),
+        "author": book.get("author"),
+        "my_rating": book.get("my_rating"),
+        "my_review": book.get("my_review"),
+        "shelves": book.get("shelves", []),
+        "date_read": book.get("date_read"),
+        "date_added": book.get("date_added"),
+        "read_events": book.get("read_events", []),
+        "note_count": int(book.get("note_count") or 0),
+    }
+    if include_notes:
+        entry["notes"] = [
+            {
+                "note_type": note.get("note_type"),
+                "content": note.get("content"),
+                "page_or_location": note.get("page_or_location"),
+                "created_at": note.get("created_at"),
+            }
+            for note in (book.get("notes") or [])[:notes_limit]
+            if isinstance(note, dict) and str(note.get("content") or "").strip()
+        ]
+    if extra:
+        entry.update(extra)
+    return entry
+
+
+def _read_completion_count(book: dict[str, Any]) -> int:
+    return sum(
+        1
+        for event in (book.get("read_events") or [])
+        if isinstance(event, dict) and event.get("finished_on")
+    )
+
+
+def _historical_anchor_score(book: dict[str, Any]) -> float:
+    rating = int(book.get("my_rating") or 0)
+    review_length = len(str(book.get("my_review") or ""))
+    note_count = int(book.get("note_count") or 0)
+    reread_count = max(0, _read_completion_count(book) - 1)
+    return (
+        rating * 20
+        + min(review_length / 120, 20)
+        + min(note_count * 8, 32)
+        + reread_count * 14
+    )
+
+
+def _historical_anchor_reasons(book: dict[str, Any]) -> list[str]:
+    reasons: list[str] = []
+    if int(book.get("my_rating") or 0) >= 5:
+        reasons.append("high_rating")
+    if len(str(book.get("my_review") or "")) >= 600:
+        reasons.append("substantial_review")
+    if int(book.get("note_count") or 0) > 0:
+        reasons.append("has_notes")
+    if _read_completion_count(book) > 1:
+        reasons.append("reread")
+    return reasons or ["representative_older_read"]
+
+
+def _stable_sample_key(book: dict[str, Any]) -> str:
+    title = str(book.get("title") or "").strip().lower()
+    author = str(book.get("author") or "").strip().lower()
+    return hashlib.sha256(f"taste-profile-sample-v1\0{title}\0{author}".encode("utf-8")).hexdigest()
+
+
+def build_taste_profile_snapshot(books_payload: dict[str, Any]) -> dict[str, Any]:
+    books = books_payload.get("books", {})
+    read_books = [book for book in books.get("read", []) if isinstance(book, dict)]
+    currently_reading = [
+        book
+        for book in books.get("currently_reading", [])
+        if isinstance(book, dict)
+        and any(str(note.get("content") or "").strip() for note in (book.get("notes") or []))
+    ]
+
+    recent_read_books = read_books[:RECENT_READ_LIMIT]
+    recent_keys = {_book_identity(book) for book in recent_read_books}
+    older_read_books = [book for book in read_books if _book_identity(book) not in recent_keys]
+
+    anchors = sorted(
+        older_read_books,
+        key=lambda book: (-_historical_anchor_score(book), str(book.get("date_read") or "")),
+    )[:HISTORICAL_ANCHOR_LIMIT]
+    anchor_keys = {_book_identity(book) for book in anchors}
+    sample_pool = [book for book in older_read_books if _book_identity(book) not in anchor_keys]
+    historical_sample = sorted(sample_pool, key=_stable_sample_key)[:HISTORICAL_SAMPLE_LIMIT]
 
     return {
         "stats": books_payload.get("stats", {}),
-        "read": [_read_entry(book) for book in books.get("read", [])],
+        "selection_strategy": {
+            "recent_read_books": (
+                f"Most recent {RECENT_READ_LIMIT} completed books, with ratings, shelves, "
+                "reviews, read dates, and note counts."
+            ),
+            "currently_reading_with_notes": (
+                "Only in-progress books with personal notes. These are high-signal but "
+                "provisional evidence of current preoccupations."
+            ),
+            "historical_anchors": (
+                f"Up to {HISTORICAL_ANCHOR_LIMIT} older completed books selected for high "
+                "rating, substantial review text, note count, or rereading."
+            ),
+            "historical_sample": (
+                f"A deterministic sample of up to {HISTORICAL_SAMPLE_LIMIT} older completed "
+                "books not already selected as anchors."
+            ),
+        },
+        "recent_read_books": [_book_entry(book) for book in recent_read_books],
+        "currently_reading_with_notes": [
+            _book_entry(
+                book,
+                include_notes=True,
+                notes_limit=CURRENT_READING_NOTE_LIMIT,
+                extra={"evidence_status": "in_progress"},
+            )
+            for book in currently_reading
+        ],
+        "historical_anchors": [
+            _book_entry(
+                book,
+                include_notes=True,
+                notes_limit=1,
+                extra={
+                    "anchor_score": round(_historical_anchor_score(book), 2),
+                    "anchor_reasons": _historical_anchor_reasons(book),
+                },
+            )
+            for book in anchors
+        ],
+        "historical_sample": [_book_entry(book) for book in historical_sample],
+        "excluded_counts": {
+            "read_books_not_in_snapshot": max(
+                0,
+                len(read_books)
+                - len(recent_read_books)
+                - len(anchors)
+                - len(historical_sample),
+            ),
+            "currently_reading_without_notes": max(
+                0,
+                len([book for book in books.get("currently_reading", []) if isinstance(book, dict)])
+                - len(currently_reading),
+            ),
+        },
+    }
+
+
+def build_library_snapshot(books_payload: dict[str, Any]) -> dict[str, Any]:
+    books = books_payload.get("books", {})
+
+    return {
+        "stats": books_payload.get("stats", {}),
+        "read": [_book_entry(book) for book in books.get("read", [])],
         "currently_reading": [
             {
                 "title": book.get("title"),
@@ -345,6 +501,7 @@ def extract_json_object(raw: str) -> dict[str, Any]:
 
 def normalize_taste_profile(payload: dict[str, Any]) -> dict[str, Any]:
     summary = " ".join(str(payload.get("summary") or "").split())
+    current_drift = " ".join(str(payload.get("current_drift") or "").split())
     blind_spots = " ".join(str(payload.get("blind_spots") or "").split())
     traits: list[dict[str, str]] = []
     for item in payload.get("traits") or []:
@@ -362,6 +519,7 @@ def normalize_taste_profile(payload: dict[str, Any]) -> dict[str, Any]:
 
     return {
         "summary": summary,
+        "current_drift": current_drift,
         "traits": traits[:5],
         "blind_spots": blind_spots,
     }
@@ -799,6 +957,7 @@ async def generate_cache_payload(
         return cache_payload, True
 
     snapshot = build_library_snapshot(books_payload)
+    taste_profile_snapshot = build_taste_profile_snapshot(books_payload)
     all_books = {
         normalize_book_key(book.get("title", ""), book.get("author", ""))
         for shelf in ("read", "currently_reading")
@@ -890,7 +1049,7 @@ async def generate_cache_payload(
                 try:
                     result["taste_profile"] = await generate_taste_profile(
                         client,
-                        snapshot,
+                        taste_profile_snapshot,
                         taste_api_key,
                         debug_info=taste_profile_debug,
                         provider=taste_profile_provider,
@@ -1099,7 +1258,7 @@ def _main_sqlite(
     from bookshelf_data import BookshelfDB
 
     store = BookshelfDB(db_path)
-    books_payload = store.books()
+    books_payload = store.books(include_notes=True)
     cache_payload = store.llm_cache()
 
     generated_payload, skipped = asyncio.run(

--- a/scripts/prompts/taste_profile_prompt.txt
+++ b/scripts/prompts/taste_profile_prompt.txt
@@ -2,6 +2,7 @@ You are analyzing a real person's reading history.
 Return strict JSON only with this shape:
 {
   "summary": "2-3 sentences",
+  "current_drift": "1 sentence about what seems newly active or changing, or an honest note that no drift is visible",
   "traits": [
     {"label": "short trait label", "explanation": "one sentence explanation"}
   ],
@@ -10,12 +11,18 @@ Return strict JSON only with this shape:
 
 Rules:
 - Base every claim on patterns actually visible in the data.
-- Use ratings, shelves, and review text when available.
-- Pay special attention to the 'notes' field — these contain the reader's own reflections and are the highest-signal data about their taste. Weight notes more heavily than ratings when they conflict.
+- The input is intentionally sampled and bucketed, not the full shelf. Use selection_strategy and excluded_counts to understand what the sample represents.
+- recent_read_books are the strongest evidence for the reader's current completed-reading taste.
+- currently_reading_with_notes are high-signal evidence about live questions and current preoccupations, but they are provisional because the books are still in progress. Use them to describe current drift, not settled taste.
+- historical_anchors preserve durable older taste because they were selected for high ratings, substantial reviews, notes, or rereading.
+- historical_sample preserves breadth. Do not overfit to a single randomly sampled older book.
+- Use ratings, shelves, review text, note_count, and read history when available.
+- Pay special attention to the 'notes' field — these contain the reader's own reflections and are the highest-signal data about what is currently alive in their reading. Weight notes more heavily than ratings when they conflict, while remembering that current-reading notes are provisional.
 - Avoid generic genre summaries and empty flattery.
 - Summary is public-facing: write in warm third person ("this reader", "the reader", or "they"), not direct second person.
 - Summary should feel like a perceptive friend introducing the reader's taste to a visitor, not an academic profile, museum label, or performance review.
 - For the summary, prefer concrete, vivid phrasing over stacked abstract nouns. Include one memorable turn of phrase if the data supports it.
+- current_drift should capture what recent completed reads plus currently-reading notes suggest is newly active, intensifying, or changing. If the evidence is too thin, say that plainly.
 - Traits should describe reading personality, not genres.
 - Blind spots should feel like a clever friend teasing the reader with affection: specific, lightly funny, and grounded in the data. Roast the pattern, not the person.
 - For blind spots, avoid formal phrases like "suggesting a possible tendency," "may reflect," "gap worth noticing," or "constructively." Prefer vivid, conversational language.

--- a/site/index.html
+++ b/site/index.html
@@ -599,6 +599,13 @@
       max-width: 60ch;
     }
 
+    .taste-run-meta {
+      margin-top: 6px;
+      color: var(--muted);
+      font-size: .76rem;
+      line-height: 1.45;
+    }
+
     .taste-preview {
       margin-top: 0;
       color: var(--muted);
@@ -2204,6 +2211,7 @@
             <div class="taste-summary" id="taste-summary"></div>
             <p class="taste-drift hidden" id="taste-drift"></p>
             <p class="taste-meta">Not a verdict, just a compact read on what the shelf suggests when you step back from the individual spines.</p>
+            <p class="taste-run-meta hidden" id="taste-run-meta"></p>
           </div>
           <button class="taste-inline-toggle is-collapse" id="taste-collapse-toggle" type="button">Show less</button>
           <div class="traits-grid" id="traits-grid"></div>
@@ -3211,6 +3219,8 @@ function renderTasteProfile(profile) {
     document.getElementById('taste-summary').textContent = '';
     document.getElementById('taste-drift').textContent = '';
     document.getElementById('taste-drift').classList.add('hidden');
+    document.getElementById('taste-run-meta').textContent = '';
+    document.getElementById('taste-run-meta').classList.add('hidden');
     document.getElementById('taste-preview').textContent = '';
     document.getElementById('traits-grid').innerHTML = '';
     document.getElementById('blind-spot').innerHTML = '';
@@ -3233,6 +3243,16 @@ function renderTasteProfile(profile) {
     ? `${tasteProfilePayload.summary.slice(0, 220).trimEnd()}...`
     : tasteProfilePayload.summary;
   document.getElementById('taste-preview').textContent = preview;
+  const tasteRunMetaEl = document.getElementById('taste-run-meta');
+  const tasteTargetState = llmTargetHealth('taste_profile');
+  const tasteGeneratedAt = tasteTargetState && tasteTargetState.generated_at;
+  if (tasteGeneratedAt) {
+    tasteRunMetaEl.textContent = `Taste profile last generated on ${formatLongDate(tasteGeneratedAt)}.`;
+    tasteRunMetaEl.classList.remove('hidden');
+  } else {
+    tasteRunMetaEl.textContent = '';
+    tasteRunMetaEl.classList.add('hidden');
+  }
   document.getElementById('traits-grid').innerHTML = (tasteProfilePayload.traits || []).map(trait => `
     <article class="trait-card">
       <h3 class="trait-title">${escHtml(trait.label)}</h3>
@@ -3384,6 +3404,7 @@ async function refreshHealthPayload() {
   healthPayload = payload;
   renderStagingBanner(healthPayload);
   syncLlmAdminControls();
+  if (tasteProfilePayload) renderTasteProfile(tasteProfilePayload);
   updateFooter(booksGeneratedAt);
   return payload;
 }
@@ -3499,6 +3520,7 @@ async function load() {
     healthPayload = healthResult.value;
     renderStagingBanner(healthPayload);
     syncLlmAdminControls();
+    if (tasteProfilePayload) renderTasteProfile(tasteProfilePayload);
   }
 
   const data = booksResult.value;

--- a/site/index.html
+++ b/site/index.html
@@ -579,6 +579,18 @@
       color: var(--text);
     }
 
+    .taste-drift {
+      margin-top: 12px;
+      max-width: 68ch;
+      color: var(--text);
+      font-size: .9rem;
+      line-height: 1.58;
+    }
+
+    .taste-drift strong {
+      font-weight: 700;
+    }
+
     .taste-meta {
       margin-top: 12px;
       color: var(--muted);
@@ -2190,6 +2202,7 @@
           <div class="taste-summary-card">
             <div class="taste-summary-label">Reading sketch</div>
             <div class="taste-summary" id="taste-summary"></div>
+            <p class="taste-drift hidden" id="taste-drift"></p>
             <p class="taste-meta">Not a verdict, just a compact read on what the shelf suggests when you step back from the individual spines.</p>
           </div>
           <button class="taste-inline-toggle is-collapse" id="taste-collapse-toggle" type="button">Show less</button>
@@ -3196,6 +3209,8 @@ function renderTasteProfile(profile) {
     emptyState.textContent = 'Taste profile not generated yet. Refresh taste profile to populate this section.';
     emptyState.classList.remove('hidden');
     document.getElementById('taste-summary').textContent = '';
+    document.getElementById('taste-drift').textContent = '';
+    document.getElementById('taste-drift').classList.add('hidden');
     document.getElementById('taste-preview').textContent = '';
     document.getElementById('traits-grid').innerHTML = '';
     document.getElementById('blind-spot').innerHTML = '';
@@ -3206,6 +3221,14 @@ function renderTasteProfile(profile) {
   tastePreviewShellEl.classList.remove('hidden');
   tasteContentEl.classList.remove('hidden');
   document.getElementById('taste-summary').textContent = tasteProfilePayload.summary;
+  const driftEl = document.getElementById('taste-drift');
+  if (tasteProfilePayload.current_drift) {
+    driftEl.innerHTML = `<strong>Current drift.</strong> ${escHtml(tasteProfilePayload.current_drift)}`;
+    driftEl.classList.remove('hidden');
+  } else {
+    driftEl.textContent = '';
+    driftEl.classList.add('hidden');
+  }
   const preview = tasteProfilePayload.summary.length > 220
     ? `${tasteProfilePayload.summary.slice(0, 220).trimEnd()}...`
     : tasteProfilePayload.summary;

--- a/tests/test_generate_llm.py
+++ b/tests/test_generate_llm.py
@@ -82,13 +82,65 @@ class GenerateLlmTests(unittest.TestCase):
 
         self.assertNotEqual(original_hash, compute_llm_input_hash(books_payload))
 
-    def test_llm_input_hash_ignores_notes(self):
+    def test_llm_input_hash_changes_when_notes_change(self):
         books_payload = sample_books_payload()
         original_hash = compute_llm_input_hash(books_payload)
 
-        books_payload["books"]["read"][0]["notes"] = "A private note should not affect freshness."
+        books_payload["books"]["currently_reading"].append(
+            {
+                "title": "Live Book",
+                "author": "Author Three",
+                "notes": [{"id": 1, "note_type": "thought", "content": "Fresh obsession."}],
+            }
+        )
 
-        self.assertEqual(original_hash, compute_llm_input_hash(books_payload))
+        self.assertNotEqual(original_hash, compute_llm_input_hash(books_payload))
+
+    def test_taste_profile_snapshot_uses_bucketed_input(self):
+        books_payload = sample_books_payload()
+        books_payload["books"]["read"] = [
+            {
+                "title": f"Book {index:02d}",
+                "author": "Author",
+                "my_rating": 5 if index == 55 else 3,
+                "my_review": "Long review. " * (80 if index == 56 else 1),
+                "shelves": ["history"],
+                "date_read": f"2026-02-{(index % 28) + 1:02d}",
+                "date_added": f"2026-01-{(index % 28) + 1:02d}",
+                "read_events": [{"finished_on": f"2026-02-{(index % 28) + 1:02d}"}],
+                "note_count": 1 if index == 57 else 0,
+                "notes": [{"id": 9, "note_type": "thought", "content": "Older live wire."}]
+                if index == 57
+                else [],
+            }
+            for index in range(60)
+        ]
+        books_payload["books"]["currently_reading"] = [
+            {
+                "title": "In Progress With Notes",
+                "author": "Reader",
+                "notes": [
+                    {"id": 2, "note_type": "question", "content": "What is changing?"},
+                    {"id": 1, "note_type": "thought", "content": "Something is brewing."},
+                    {"id": 0, "note_type": "thought", "content": "Older note."},
+                ],
+                "note_count": 3,
+            },
+            {"title": "In Progress Without Notes", "author": "Reader", "notes": []},
+        ]
+
+        snapshot = generate_llm.build_taste_profile_snapshot(books_payload)
+
+        self.assertEqual(len(snapshot["recent_read_books"]), 50)
+        self.assertEqual(
+            snapshot["currently_reading_with_notes"][0]["title"],
+            "In Progress With Notes",
+        )
+        self.assertEqual(len(snapshot["currently_reading_with_notes"][0]["notes"]), 2)
+        self.assertEqual(snapshot["currently_reading_with_notes"][0]["evidence_status"], "in_progress")
+        self.assertGreaterEqual(len(snapshot["historical_anchors"]), 1)
+        self.assertIn("selection_strategy", snapshot)
+        self.assertEqual(snapshot["excluded_counts"]["currently_reading_without_notes"], 1)
 
     def test_skip_generation_when_hash_matches(self):
         books_payload = sample_books_payload()


### PR DESCRIPTION
## Summary

- Reworks taste-profile generation to use a bucketed private snapshot: recent completed reads, currently-reading books with notes, historical anchors, and a deterministic historical sample.
- Adds private note enrichment for LLM generation without exposing notes on the public books API.
- Updates the taste-profile prompt and UI to support a `current_drift` line.
- Updates LLM freshness hashing so currently-reading books only affect the cache when they include notes.

## Why

The previous all-read-books input made taste profiles too static. New completed reads or note-heavy current reads had very little influence because they were diluted by the whole shelf.

## Validation

- `python -m py_compile bookshelf_data.py scripts/generate_llm.py api/main.py`
- `.venv/bin/python -m unittest tests.test_generate_llm`
- `.venv/bin/python -m unittest tests.test_api`
- `.venv/bin/python -m unittest tests.test_db`

## Notes

Untracked local data/log artifacts were intentionally left out of this PR.
