### PR TITLE
[codex] Bucket recommendation input

### DIFF
--- a/README.md
+++ b/README.md
@@ -494,6 +494,7 @@ make restart-staging-api
 - OpenAI powers one recommendation column and can also generate the taste profile with `--taste-profile-provider openai`
 - Gemini powers one recommendation column
 - the taste profile uses a bucketed snapshot: recent completed reads, currently-reading books with notes, older high-signal anchors, and a deterministic historical sample
+- recommendations use a recent/current-heavy snapshot and intentionally omit the to-read shelf; to-read overlap is marked after generation by matching title/author
 - partial refreshes are supported by provider
 - `LLM_DRY_RUN=true` writes placeholders instead of making live model calls
 

--- a/api/main.py
+++ b/api/main.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import os
 import sys
+from copy import deepcopy
 from pathlib import Path
 
 from fastapi import FastAPI, HTTPException, Request
@@ -16,6 +17,7 @@ from bookshelf_data import (
     BookshelfStore,
     LLM_TARGET_KEYS,
     load_env_file,
+    normalize_book_key,
     utc_now_iso,
 )
 from api.activity import router as activity_router
@@ -341,7 +343,23 @@ async def get_recommendations() -> dict:
     recommendations = store.recommendations()
     if recommendations is None:
         raise HTTPException(status_code=404, detail="Recommendations are unavailable.")
-    return recommendations
+
+    payload = deepcopy(recommendations)
+    books_payload = store.books()
+    to_read_books = {
+        normalize_book_key(book.get("title", ""), book.get("author", ""))
+        for book in books_payload.get("books", {}).get("to_read", [])
+        if isinstance(book, dict)
+    }
+    for entry in payload.values():
+        if not isinstance(entry, dict):
+            continue
+        for book in entry.get("books") or []:
+            if not isinstance(book, dict):
+                continue
+            key = normalize_book_key(book.get("title", ""), book.get("author", ""))
+            book["from_to_read"] = bool(book.get("from_to_read")) or key in to_read_books
+    return payload
 
 
 # ── CRUD endpoints ───────────────────────────────────────────────────────────

--- a/scripts/generate_llm.py
+++ b/scripts/generate_llm.py
@@ -257,6 +257,8 @@ RECENT_READ_LIMIT = 50
 CURRENT_READING_NOTE_LIMIT = 2
 HISTORICAL_ANCHOR_LIMIT = 25
 HISTORICAL_SAMPLE_LIMIT = 50
+RECOMMENDATION_RECENT_READ_LIMIT = 40
+RECOMMENDATION_ANCHOR_LIMIT = 20
 
 
 def _book_identity(book: dict[str, Any]) -> tuple[str, str]:
@@ -419,6 +421,84 @@ def build_taste_profile_snapshot(books_payload: dict[str, Any]) -> dict[str, Any
     }
 
 
+def build_recommendations_snapshot(books_payload: dict[str, Any]) -> dict[str, Any]:
+    books = books_payload.get("books", {})
+    read_books = [book for book in books.get("read", []) if isinstance(book, dict)]
+    currently_reading = [
+        book
+        for book in books.get("currently_reading", [])
+        if isinstance(book, dict)
+        and any(str(note.get("content") or "").strip() for note in (book.get("notes") or []))
+    ]
+
+    recent_read_books = read_books[:RECOMMENDATION_RECENT_READ_LIMIT]
+    recent_keys = {_book_identity(book) for book in recent_read_books}
+    older_read_books = [book for book in read_books if _book_identity(book) not in recent_keys]
+    anchors = sorted(
+        older_read_books,
+        key=lambda book: (-_historical_anchor_score(book), str(book.get("date_read") or "")),
+    )[:RECOMMENDATION_ANCHOR_LIMIT]
+
+    return {
+        "stats": books_payload.get("stats", {}),
+        "selection_strategy": {
+            "recent_read_books": (
+                f"Most recent {RECOMMENDATION_RECENT_READ_LIMIT} completed books. "
+                "Use these as the strongest signal for what would fit now."
+            ),
+            "currently_reading_with_notes": (
+                "Only in-progress books with personal notes. These are high-signal "
+                "evidence of current preoccupations, but provisional."
+            ),
+            "historical_anchors": (
+                f"Up to {RECOMMENDATION_ANCHOR_LIMIT} older high-signal books selected "
+                "for high ratings, substantial reviews, note count, or rereading."
+            ),
+            "to_read_policy": (
+                "The to_read shelf is intentionally omitted so recommendations can surface "
+                "unknown unknowns. Whether a recommendation is already on to_read is marked "
+                "after model generation by exact title/author matching."
+            ),
+        },
+        "recent_read_books": [_book_entry(book) for book in recent_read_books],
+        "currently_reading_with_notes": [
+            _book_entry(
+                book,
+                include_notes=True,
+                notes_limit=CURRENT_READING_NOTE_LIMIT,
+                extra={"evidence_status": "in_progress"},
+            )
+            for book in currently_reading
+        ],
+        "historical_anchors": [
+            _book_entry(
+                book,
+                include_notes=True,
+                notes_limit=1,
+                extra={
+                    "anchor_score": round(_historical_anchor_score(book), 2),
+                    "anchor_reasons": _historical_anchor_reasons(book),
+                },
+            )
+            for book in anchors
+        ],
+        "excluded_counts": {
+            "read_books_not_in_snapshot": max(
+                0,
+                len(read_books) - len(recent_read_books) - len(anchors),
+            ),
+            "currently_reading_without_notes": max(
+                0,
+                len([book for book in books.get("currently_reading", []) if isinstance(book, dict)])
+                - len(currently_reading),
+            ),
+            "to_read_books_omitted": len(
+                [book for book in books.get("to_read", []) if isinstance(book, dict)]
+            ),
+        },
+    }
+
+
 def build_library_snapshot(books_payload: dict[str, Any]) -> dict[str, Any]:
     books = books_payload.get("books", {})
 
@@ -526,10 +606,13 @@ def normalize_taste_profile(payload: dict[str, Any]) -> dict[str, Any]:
 
 
 def normalize_recommendations(
-    payload: dict[str, Any], existing_books: set[tuple[str, str]]
+    payload: dict[str, Any],
+    existing_books: set[tuple[str, str]],
+    to_read_books: set[tuple[str, str]] | None = None,
 ) -> dict[str, Any]:
     cleaned_books: list[dict[str, str]] = []
     seen: set[tuple[str, str]] = set()
+    to_read_books = to_read_books or set()
 
     for item in payload.get("books") or []:
         if not isinstance(item, dict):
@@ -545,7 +628,7 @@ def normalize_recommendations(
         if not title or not author or not reason or key in seen or key in existing_books:
             continue
 
-        from_to_read = bool(item.get("from_to_read"))
+        from_to_read = bool(item.get("from_to_read")) or key in to_read_books
         seen.add(key)
         cleaned_books.append(
             {
@@ -773,6 +856,7 @@ async def generate_anthropic_recommendations(
     snapshot: dict[str, Any],
     api_key: str,
     existing_books: set[tuple[str, str]],
+    to_read_books: set[tuple[str, str]] | None = None,
     debug_info: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     raw, response_debug = await with_retry(
@@ -782,7 +866,7 @@ async def generate_anthropic_recommendations(
     if debug_info is not None:
         debug_info.update(response_debug)
     try:
-        normalized = normalize_recommendations(raw, existing_books)
+        normalized = normalize_recommendations(raw, existing_books, to_read_books)
     except Exception as exc:  # noqa: BLE001
         raise ProviderResponseError(str(exc), debug_info=response_debug) from exc
     normalized["model"] = ANTHROPIC_MODEL
@@ -794,6 +878,7 @@ async def generate_openai_recommendations(
     snapshot: dict[str, Any],
     api_key: str,
     existing_books: set[tuple[str, str]],
+    to_read_books: set[tuple[str, str]] | None = None,
     debug_info: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     raw, response_debug = await with_retry(
@@ -803,7 +888,7 @@ async def generate_openai_recommendations(
     if debug_info is not None:
         debug_info.update(response_debug)
     try:
-        normalized = normalize_recommendations(raw, existing_books)
+        normalized = normalize_recommendations(raw, existing_books, to_read_books)
     except Exception as exc:  # noqa: BLE001
         raise ProviderResponseError(str(exc), debug_info=response_debug) from exc
     normalized["model"] = OPENAI_MODEL
@@ -815,6 +900,7 @@ async def generate_gemini_recommendations(
     snapshot: dict[str, Any],
     api_key: str,
     existing_books: set[tuple[str, str]],
+    to_read_books: set[tuple[str, str]] | None = None,
     debug_info: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     raw, response_debug = await with_retry(
@@ -829,7 +915,7 @@ async def generate_gemini_recommendations(
     if debug_info is not None:
         debug_info.update(response_debug)
     try:
-        normalized = normalize_recommendations(raw, existing_books)
+        normalized = normalize_recommendations(raw, existing_books, to_read_books)
     except Exception as exc:  # noqa: BLE001
         raise ProviderResponseError(str(exc), debug_info=response_debug) from exc
     normalized["model"] = GEMINI_MODEL
@@ -956,12 +1042,16 @@ async def generate_cache_payload(
     ):
         return cache_payload, True
 
-    snapshot = build_library_snapshot(books_payload)
+    recommendation_snapshot = build_recommendations_snapshot(books_payload)
     taste_profile_snapshot = build_taste_profile_snapshot(books_payload)
     all_books = {
         normalize_book_key(book.get("title", ""), book.get("author", ""))
         for shelf in ("read", "currently_reading")
         for book in books_payload.get("books", {}).get(shelf, [])
+    }
+    to_read_books = {
+        normalize_book_key(book.get("title", ""), book.get("author", ""))
+        for book in books_payload.get("books", {}).get("to_read", [])
     }
 
     anthropic_key = os.getenv("ANTHROPIC_API_KEY", "").strip()
@@ -1085,9 +1175,10 @@ async def generate_cache_payload(
                 anthropic_key,
                 lambda: generate_anthropic_recommendations(
                     client,
-                    snapshot,
+                    recommendation_snapshot,
                     anthropic_key,
                     all_books,
+                    to_read_books,
                     debug_info=recommendation_debug["opus"],
                 ),
                 "ANTHROPIC_API_KEY is not set.",
@@ -1096,9 +1187,10 @@ async def generate_cache_payload(
                 openai_key,
                 lambda: generate_openai_recommendations(
                     client,
-                    snapshot,
+                    recommendation_snapshot,
                     openai_key,
                     all_books,
+                    to_read_books,
                     debug_info=recommendation_debug["gpt45"],
                 ),
                 "OPENAI_API_KEY is not set.",
@@ -1107,9 +1199,10 @@ async def generate_cache_payload(
                 gemini_key,
                 lambda: generate_gemini_recommendations(
                     client,
-                    snapshot,
+                    recommendation_snapshot,
                     gemini_key,
                     all_books,
+                    to_read_books,
                     debug_info=recommendation_debug["gemini"],
                 ),
                 "GEMINI_API_KEY or GOOGLE_API_KEY is not set.",

--- a/scripts/generate_llm.py
+++ b/scripts/generate_llm.py
@@ -258,6 +258,7 @@ CURRENT_READING_NOTE_LIMIT = 2
 HISTORICAL_ANCHOR_LIMIT = 25
 HISTORICAL_SAMPLE_LIMIT = 50
 RECOMMENDATION_RECENT_READ_LIMIT = 40
+RECOMMENDATION_CURRENT_READING_LIMIT = 3
 RECOMMENDATION_ANCHOR_LIMIT = 20
 
 
@@ -424,12 +425,13 @@ def build_taste_profile_snapshot(books_payload: dict[str, Any]) -> dict[str, Any
 def build_recommendations_snapshot(books_payload: dict[str, Any]) -> dict[str, Any]:
     books = books_payload.get("books", {})
     read_books = [book for book in books.get("read", []) if isinstance(book, dict)]
-    currently_reading = [
+    currently_reading_with_notes = [
         book
         for book in books.get("currently_reading", [])
         if isinstance(book, dict)
         and any(str(note.get("content") or "").strip() for note in (book.get("notes") or []))
     ]
+    selected_currently_reading = currently_reading_with_notes[:RECOMMENDATION_CURRENT_READING_LIMIT]
 
     recent_read_books = read_books[:RECOMMENDATION_RECENT_READ_LIMIT]
     recent_keys = {_book_identity(book) for book in recent_read_books}
@@ -447,8 +449,9 @@ def build_recommendations_snapshot(books_payload: dict[str, Any]) -> dict[str, A
                 "Use these as the strongest signal for what would fit now."
             ),
             "currently_reading_with_notes": (
-                "Only in-progress books with personal notes. These are high-signal "
-                "evidence of current preoccupations, but provisional."
+                f"Up to {RECOMMENDATION_CURRENT_READING_LIMIT} in-progress books with "
+                "personal notes. These are high-signal evidence of current preoccupations, "
+                "but provisional."
             ),
             "historical_anchors": (
                 f"Up to {RECOMMENDATION_ANCHOR_LIMIT} older high-signal books selected "
@@ -468,7 +471,7 @@ def build_recommendations_snapshot(books_payload: dict[str, Any]) -> dict[str, A
                 notes_limit=CURRENT_READING_NOTE_LIMIT,
                 extra={"evidence_status": "in_progress"},
             )
-            for book in currently_reading
+            for book in selected_currently_reading
         ],
         "historical_anchors": [
             _book_entry(
@@ -490,7 +493,11 @@ def build_recommendations_snapshot(books_payload: dict[str, Any]) -> dict[str, A
             "currently_reading_without_notes": max(
                 0,
                 len([book for book in books.get("currently_reading", []) if isinstance(book, dict)])
-                - len(currently_reading),
+                - len(currently_reading_with_notes),
+            ),
+            "currently_reading_with_notes_not_in_snapshot": max(
+                0,
+                len(currently_reading_with_notes) - len(selected_currently_reading),
             ),
             "to_read_books_omitted": len(
                 [book for book in books.get("to_read", []) if isinstance(book, dict)]

--- a/scripts/prompts/recommendations_prompt.txt
+++ b/scripts/prompts/recommendations_prompt.txt
@@ -16,7 +16,12 @@ Return strict JSON only with this shape:
 Rules:
 - Recommend exactly 5 books if possible.
 - Do not recommend any book already present in read or currently_reading.
-- You MAY recommend books from the to_read shelf — if you do, set from_to_read to true and explain why that book is particularly well-suited given the reading history.
+- The to_read shelf is intentionally not included in the input. Do not optimize for books the reader already knows about; aim for unknown unknowns.
+- Always set from_to_read to false. The app will mark this field after generation if the recommended title/author is already present on the reader's to-read shelf.
+- The input is intentionally recent/current-heavy, not the full shelf. Use selection_strategy and excluded_counts to understand what the sample represents.
+- recent_read_books are the strongest evidence for what would fit the reader now.
+- currently_reading_with_notes are high-signal evidence about live questions and current preoccupations, but provisional because the books are still in progress.
+- historical_anchors preserve durable taste from older high-signal books without letting the lifetime shelf flatten current interests.
 - Use the reader's reviews (my_review field) as the primary evidence for their preferences — reviews reveal what they actually valued or disliked, not just what they finished.
 - The reader's personal notes (notes field) reveal what specifically resonates with them beyond genre or topic. Use notes to identify the *type of thinking* they value, not just the subjects. Reference specific notes when explaining why a recommendation fits.
 - Treat high ratings without a review as weaker signal than a detailed review at any rating.

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -32,7 +32,7 @@ class ApiTests(unittest.TestCase):
                     "books": {
                         "read": [{"title": "Book A", "author": "Author One", "my_rating": 5}],
                         "currently_reading": [],
-                        "to_read": [],
+                        "to_read": [{"title": "Rec A", "author": "Author A"}],
                     },
                     "stats": {"total_read": 1},
                 }
@@ -103,6 +103,7 @@ class ApiTests(unittest.TestCase):
         self.assertIn("opus", payload)
         self.assertIn("gemini", payload)
         self.assertEqual(payload["opus"]["books"][0]["title"], "Rec A")
+        self.assertTrue(payload["opus"]["books"][0]["from_to_read"])
 
     def test_health_endpoint_prefers_llm_timestamp(self):
         response = self.client.get("/api/health")

--- a/tests/test_generate_llm.py
+++ b/tests/test_generate_llm.py
@@ -161,14 +161,24 @@ class GenerateLlmTests(unittest.TestCase):
         ]
         books_payload["books"]["currently_reading"] = [
             {
-                "title": "Live Wire",
+                "title": f"Live Wire {index}",
                 "author": "Reader",
                 "notes": [
-                    {"id": 2, "note_type": "question", "content": "What should come next?"},
-                    {"id": 1, "note_type": "thought", "content": "This feels urgent."},
+                    {
+                        "id": 2,
+                        "note_type": "question",
+                        "content": f"What should come next {index}?",
+                    },
+                    {
+                        "id": 1,
+                        "note_type": "thought",
+                        "content": f"This feels urgent {index}.",
+                    },
                 ],
                 "note_count": 2,
-            },
+            }
+            for index in range(4)
+        ] + [
             {"title": "No Notes Yet", "author": "Reader", "notes": []},
         ]
         books_payload["books"]["to_read"] = [
@@ -179,7 +189,12 @@ class GenerateLlmTests(unittest.TestCase):
         serialized = json_dump(snapshot)
 
         self.assertEqual(len(snapshot["recent_read_books"]), 40)
-        self.assertEqual(snapshot["currently_reading_with_notes"][0]["title"], "Live Wire")
+        self.assertEqual(len(snapshot["currently_reading_with_notes"]), 3)
+        self.assertEqual(snapshot["currently_reading_with_notes"][0]["title"], "Live Wire 0")
+        self.assertEqual(
+            snapshot["excluded_counts"]["currently_reading_with_notes_not_in_snapshot"],
+            1,
+        )
         self.assertNotIn("to_read", snapshot)
         self.assertNotIn("Known Unknown", serialized)
         self.assertEqual(snapshot["excluded_counts"]["to_read_books_omitted"], 1)

--- a/tests/test_generate_llm.py
+++ b/tests/test_generate_llm.py
@@ -142,6 +142,70 @@ class GenerateLlmTests(unittest.TestCase):
         self.assertIn("selection_strategy", snapshot)
         self.assertEqual(snapshot["excluded_counts"]["currently_reading_without_notes"], 1)
 
+    def test_recommendations_snapshot_omits_to_read_and_prioritizes_current_context(self):
+        books_payload = sample_books_payload()
+        books_payload["books"]["read"] = [
+            {
+                "title": f"Book {index:02d}",
+                "author": "Author",
+                "my_rating": 5 if index == 45 else 3,
+                "my_review": "Long review. " * (80 if index == 46 else 1),
+                "shelves": ["history"],
+                "date_read": f"2026-02-{(index % 28) + 1:02d}",
+                "date_added": f"2026-01-{(index % 28) + 1:02d}",
+                "read_events": [{"finished_on": f"2026-02-{(index % 28) + 1:02d}"}],
+                "note_count": 0,
+                "notes": [],
+            }
+            for index in range(60)
+        ]
+        books_payload["books"]["currently_reading"] = [
+            {
+                "title": "Live Wire",
+                "author": "Reader",
+                "notes": [
+                    {"id": 2, "note_type": "question", "content": "What should come next?"},
+                    {"id": 1, "note_type": "thought", "content": "This feels urgent."},
+                ],
+                "note_count": 2,
+            },
+            {"title": "No Notes Yet", "author": "Reader", "notes": []},
+        ]
+        books_payload["books"]["to_read"] = [
+            {"title": "Known Unknown", "author": "Future Author"},
+        ]
+
+        snapshot = generate_llm.build_recommendations_snapshot(books_payload)
+        serialized = json_dump(snapshot)
+
+        self.assertEqual(len(snapshot["recent_read_books"]), 40)
+        self.assertEqual(snapshot["currently_reading_with_notes"][0]["title"], "Live Wire")
+        self.assertNotIn("to_read", snapshot)
+        self.assertNotIn("Known Unknown", serialized)
+        self.assertEqual(snapshot["excluded_counts"]["to_read_books_omitted"], 1)
+
+    def test_recommendation_normalization_marks_to_read_matches_after_generation(self):
+        raw = {
+            "reasoning": "A strategy.",
+            "books": [
+                {
+                    "title": "Known Unknown",
+                    "author": "Future Author",
+                    "reason": "Specific reason.",
+                    "confidence": "high",
+                    "from_to_read": False,
+                }
+            ],
+        }
+
+        normalized = generate_llm.normalize_recommendations(
+            raw,
+            existing_books=set(),
+            to_read_books={("known unknown", "future author")},
+        )
+
+        self.assertTrue(normalized["books"][0]["from_to_read"])
+
     def test_skip_generation_when_hash_matches(self):
         books_payload = sample_books_payload()
         books_hash = compute_llm_input_hash(books_payload)
@@ -680,7 +744,7 @@ class GenerateLlmTests(unittest.TestCase):
         gemini_snapshot = gemini_mock.await_args.args[1]
         self.assertEqual(
             gemini_snapshot,
-            generate_llm.build_library_snapshot(books_payload),
+            generate_llm.build_recommendations_snapshot(books_payload),
         )
 
     def test_dry_run_skips_live_provider_calls(self):


### PR DESCRIPTION
## Summary

- Changes recommendation generation to use a recent/current-heavy snapshot: recent completed reads, currently-reading books with notes, and older high-signal anchors.
- Intentionally omits the to-read shelf from the recommendation prompt so models can surface unknown unknowns.
- Marks `from_to_read` after generation, and again when serving cached recommendations, by matching recommended title/author against the current to-read shelf.
- Updates tests and docs for the new recommendation-input behavior.

## Validation

- `python -m py_compile scripts/generate_llm.py api/main.py`
- `.venv/bin/python -m unittest tests.test_generate_llm`
- `.venv/bin/python -m unittest tests.test_api`
- `.venv/bin/python -m unittest tests.test_db`
