### PR TITLE
Add image upload for review editor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 data/goodreads_library_export.csv
 
 # Generated files
+data/uploads/
 data/books.json
 data/llm_cache.json
 data/llm_cache.staging.json

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ FORCE_LLM ?= 0
 
 .PHONY: install parse llm llm-force llm-staging llm-staging-force build refresh-data dev \
         deploy deploy-sync restart-api restart-bot backup pull-db push-db \
+        pull-uploads push-uploads vps-install-deps \
         deploy-staging deploy-staging-sync restart-staging-api seed-staging \
         add-notes-table add-capture-table \
         bot-status bot-logs bot-restart
@@ -83,7 +84,7 @@ deploy: backup deploy-sync restart-api restart-bot
 
 deploy-sync:
 	@echo "Syncing code to $(VPS_HOST):$(VPS_PATH)"
-	ssh $(VPS_HOST) 'mkdir -p $(VPS_PATH)/site $(VPS_PATH)/data $(VPS_PATH)/api $(VPS_PATH)/scripts $(VPS_PATH)/deploy'
+	ssh $(VPS_HOST) 'mkdir -p $(VPS_PATH)/site $(VPS_PATH)/data $(VPS_PATH)/data/uploads $(VPS_PATH)/api $(VPS_PATH)/scripts $(VPS_PATH)/deploy && chown -R www-data:www-data $(VPS_PATH)/data/uploads'
 	rsync -avz --delete site/ $(VPS_HOST):$(VPS_PATH)/site/
 	rsync -avz api/ $(VPS_HOST):$(VPS_PATH)/api/
 	rsync -avz scripts/ $(VPS_HOST):$(VPS_PATH)/scripts/
@@ -112,7 +113,7 @@ deploy-staging: deploy-staging-sync restart-staging-api
 
 deploy-staging-sync:
 	@echo "Syncing code to $(STAGING_VPS_HOST):$(STAGING_VPS_PATH)"
-	ssh $(STAGING_VPS_HOST) 'mkdir -p $(STAGING_VPS_PATH)/site $(STAGING_VPS_PATH)/data $(STAGING_VPS_PATH)/api $(STAGING_VPS_PATH)/scripts $(STAGING_VPS_PATH)/deploy'
+	ssh $(STAGING_VPS_HOST) 'mkdir -p $(STAGING_VPS_PATH)/site $(STAGING_VPS_PATH)/data $(STAGING_VPS_PATH)/data/uploads $(STAGING_VPS_PATH)/api $(STAGING_VPS_PATH)/scripts $(STAGING_VPS_PATH)/deploy && chown -R www-data:www-data $(STAGING_VPS_PATH)/data/uploads'
 	rsync -avz --delete site/ $(STAGING_VPS_HOST):$(STAGING_VPS_PATH)/site/
 	rsync -avz api/ $(STAGING_VPS_HOST):$(STAGING_VPS_PATH)/api/
 	rsync -avz scripts/ $(STAGING_VPS_HOST):$(STAGING_VPS_PATH)/scripts/
@@ -137,6 +138,19 @@ push-db:
 	scp data/bookshelf.db $(VPS_HOST):$(VPS_PATH)/data/bookshelf.db
 	@echo "Pushed. Restart the API to pick up the new database:"
 	@echo "  make restart-api"
+
+pull-uploads:
+	@echo "Pulling uploaded images from production…"
+	rsync -avz $(VPS_HOST):$(VPS_PATH)/data/uploads/ data/uploads/
+	@echo "Done. Local data/uploads updated."
+
+push-uploads:
+	@echo "Pushing local uploaded images to production…"
+	rsync -avz data/uploads/ $(VPS_HOST):$(VPS_PATH)/data/uploads/
+	@echo "Done."
+
+vps-install-deps:
+	ssh $(VPS_HOST) '$(VPS_PATH)/.venv/bin/pip install -r $(VPS_PATH)/api/requirements.txt'
 
 seed-staging:
 	@echo "Copying production DB to staging on VPS…"

--- a/api/main.py
+++ b/api/main.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 from fastapi import FastAPI, HTTPException, Request
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.staticfiles import StaticFiles
 
 ROOT_DIR = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT_DIR))
@@ -25,6 +26,7 @@ from api.auth import verify_auth
 from api.capture import router as capture_router
 from api.notes import router as notes_router
 from api.suggestions import router as suggestions_router
+from api.uploads import router as uploads_router
 
 load_env_file(ROOT_DIR / ".env")
 
@@ -32,6 +34,7 @@ DB_PATH = os.getenv("DB_PATH", "").strip()
 BOOKS_DATA_FILE = Path(os.getenv("BOOKS_DATA", "data/books.json"))
 LLM_CACHE_FILE = Path(os.getenv("LLM_CACHE_DATA", "data/llm_cache.json"))
 ENVIRONMENT = (os.getenv("ENVIRONMENT", "production") or "production").strip()
+UPLOADS_DIR = Path(os.getenv("UPLOADS_DIR", "") or (ROOT_DIR / "data" / "uploads"))
 configured_origins = [
     origin.strip()
     for origin in os.getenv(
@@ -59,12 +62,16 @@ app.include_router(activity_router)
 app.include_router(capture_router)
 app.include_router(notes_router)
 app.include_router(suggestions_router)
+app.include_router(uploads_router)
 app.add_middleware(
     CORSMiddleware,
     allow_origins=CORS_ORIGINS,
     allow_methods=["GET", "POST", "PUT", "DELETE"],
     allow_headers=["*"],
 )
+
+UPLOADS_DIR.mkdir(parents=True, exist_ok=True)
+app.mount("/uploads", StaticFiles(directory=str(UPLOADS_DIR)), name="uploads")
 
 
 # ── Auth helper ──────────────────────────────────────────────────────────────

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -2,3 +2,5 @@ fastapi==0.111.0
 uvicorn[standard]==0.29.0
 httpx==0.27.0
 python-telegram-bot>=21.0
+python-multipart==0.0.9
+Pillow==10.3.0

--- a/api/uploads.py
+++ b/api/uploads.py
@@ -1,0 +1,55 @@
+"""Image upload endpoint for review/note markdown."""
+
+from __future__ import annotations
+
+import io
+import uuid
+
+from fastapi import APIRouter, File, HTTPException, Request, UploadFile
+
+router = APIRouter(prefix="/api/uploads")
+
+MAX_UPLOAD_BYTES = 15 * 1024 * 1024
+MAX_WIDTH = 1600
+WEBP_QUALITY = 82
+ALLOWED_FORMATS = {"PNG", "JPEG", "WEBP"}
+
+
+def _get_deps() -> tuple:
+    from api.main import _auth, UPLOADS_DIR
+    return _auth, UPLOADS_DIR
+
+
+@router.post("", status_code=201)
+async def create_upload(request: Request, file: UploadFile = File(...)) -> dict:
+    _auth, uploads_dir = _get_deps()
+    _auth(request)
+
+    raw = await file.read()
+    if not raw:
+        raise HTTPException(status_code=422, detail="Empty upload.")
+    if len(raw) > MAX_UPLOAD_BYTES:
+        raise HTTPException(status_code=413, detail="Image exceeds 15 MB limit.")
+
+    from PIL import Image, ImageOps, UnidentifiedImageError
+
+    try:
+        img = Image.open(io.BytesIO(raw))
+        img.load()  # force full decode: validates actual bytes, not the content-type header
+    except (UnidentifiedImageError, OSError):
+        raise HTTPException(status_code=422, detail="File is not a supported image.")
+    if img.format not in ALLOWED_FORMATS:
+        raise HTTPException(status_code=422, detail=f"Unsupported image format: {img.format}.")
+
+    # exif_transpose + re-encode also strips EXIF metadata (incl. GPS)
+    img = ImageOps.exif_transpose(img)
+    if img.width > MAX_WIDTH:
+        img.thumbnail((MAX_WIDTH, 100_000), Image.LANCZOS)
+    if img.mode not in ("RGB", "RGBA"):
+        has_alpha = "A" in img.mode or "transparency" in img.info
+        img = img.convert("RGBA" if has_alpha else "RGB")
+
+    name = f"{uuid.uuid4().hex}.webp"
+    uploads_dir.mkdir(parents=True, exist_ok=True)
+    img.save(uploads_dir / name, "WEBP", quality=WEBP_QUALITY, method=6)
+    return {"url": f"/uploads/{name}", "filename": name}

--- a/deploy/nginx.conf
+++ b/deploy/nginx.conf
@@ -25,6 +25,14 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
     }
 
+    # ^~ so this prefix beats the static-extension regex below
+    location ^~ /uploads/ {
+        alias /var/www/book.tanxy.net/data/uploads/;
+        expires 30d;
+        add_header Cache-Control "public, immutable";
+        try_files $uri =404;
+    }
+
     gzip on;
     gzip_types text/html text/css application/javascript application/json;
 

--- a/deploy/nginx.staging.conf
+++ b/deploy/nginx.staging.conf
@@ -25,6 +25,14 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
     }
 
+    # ^~ so this prefix beats the static-extension regex below
+    location ^~ /uploads/ {
+        alias /var/www/dev.book.tanxy.net/data/uploads/;
+        expires 30d;
+        add_header Cache-Control "public, immutable";
+        try_files $uri =404;
+    }
+
     gzip on;
     gzip_types text/html text/css application/javascript application/json;
 

--- a/site/book.html
+++ b/site/book.html
@@ -194,6 +194,7 @@
       font-size: 1.03rem;
       color: rgba(52, 41, 34, 0.96);
     }
+    .review-text img { max-width: 100%; height: auto; border-radius: 6px; }
     .review-text p { margin: 0 0 0.3em 0; }
     .review-text p:last-child { margin-bottom: 0; }
     .review-text blockquote {
@@ -589,7 +590,8 @@ function renderReview(book) {
   if (!review) return;
   if (typeof marked !== 'undefined') {
     marked.use({ breaks: true });
-    document.getElementById('review-text').innerHTML = marked.parse(review);
+    const source = apiBase ? review.replace(/(\]\(|src=["'])\/uploads\//g, `$1${apiBase}/uploads/`) : review;
+    document.getElementById('review-text').innerHTML = marked.parse(source);
   } else {
     document.getElementById('review-text').textContent = review;
   }

--- a/site/edit.html
+++ b/site/edit.html
@@ -330,6 +330,39 @@
       color: var(--muted);
     }
 
+    .image-tips {
+      margin-top: 14px;
+      padding: 12px 16px;
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      background: rgba(255,255,255,0.55);
+      font-size: 0.92rem;
+      color: var(--muted);
+    }
+    .image-tips > summary {
+      cursor: pointer;
+      color: var(--accent-deep);
+      font-weight: 600;
+      list-style: none;
+    }
+    .image-tips > summary::-webkit-details-marker { display: none; }
+    .image-tips > summary::before {
+      content: "▸";
+      display: inline-block;
+      margin-right: 6px;
+      transition: transform 0.15s ease;
+    }
+    .image-tips[open] > summary::before { transform: rotate(90deg); }
+    .image-tips p { margin: 10px 0 6px; }
+    .image-tips ul { margin: 6px 0 0; padding-left: 18px; }
+    .image-tips li { margin: 4px 0; line-height: 1.55; }
+    .image-tips code {
+      background: rgba(122, 92, 62, 0.08);
+      padding: 1px 6px;
+      border-radius: 4px;
+      font-size: 0.88em;
+    }
+
     .mode-toggle {
       display: inline-flex;
       gap: 6px;
@@ -381,6 +414,11 @@
       line-height: 1.72;
       color: var(--text);
       outline: none;
+      transition: border-color 0.15s ease, box-shadow 0.15s ease;
+    }
+    .review-editor.drag-over {
+      border-color: rgba(122, 92, 62, 0.9);
+      box-shadow: 0 0 0 3px rgba(122, 92, 62, 0.15), inset 0 1px 0 rgba(255,255,255,0.85);
     }
 
     .review-preview {
@@ -873,6 +911,7 @@
       flex-shrink: 0;
     }
 
+    .review-preview img { max-width: 100%; height: auto; border-radius: 6px; }
     .review-preview p { margin: 0 0 0.45em 0; }
     .review-preview p:last-child { margin-bottom: 0; }
     .review-preview blockquote {
@@ -1021,6 +1060,19 @@
           ></textarea>
           <div id="review-preview" class="review-preview hidden" aria-live="polite"></div>
         </div>
+
+        <details class="image-tips">
+          <summary>Editor tips</summary>
+          <p>Paste (Cmd+V) or drop an image onto the editor to upload it. Default insertion is <code>&lt;img src="…" width="400"&gt;</code> — tweak the number to resize.</p>
+          <ul>
+            <li><code>&lt;img src="/uploads/xxx.webp" width="300"&gt;</code> — fixed pixel width</li>
+            <li><code>&lt;img src="/uploads/xxx.webp" width="50%"&gt;</code> — half the column width</li>
+            <li><code>&lt;img src="/uploads/xxx.webp" style="max-width:400px"&gt;</code> — cap without forcing</li>
+            <li><code>&lt;img src="/uploads/xxx.webp" width="300" align="right"&gt;</code> — right-float, text wraps</li>
+            <li><code>&lt;figure&gt;&lt;img src="/uploads/xxx.webp" width="500"&gt;&lt;figcaption&gt;Caption&lt;/figcaption&gt;&lt;/figure&gt;</code></li>
+            <li>Markdown <code>![alt](/uploads/xxx.webp)</code> also works — renders at column width.</li>
+          </ul>
+        </details>
       </section>
 
       <section class="panel meta-panel">
@@ -1526,7 +1578,8 @@
       }
       configureMarked();
       if (typeof marked !== 'undefined') {
-        preview.innerHTML = marked.parse(review);
+        const source = apiBase ? review.replace(/(\]\(|src=["'])\/uploads\//g, `$1${apiBase}/uploads/`) : review;
+        preview.innerHTML = marked.parse(source);
       } else {
         preview.textContent = review;
       }
@@ -1922,6 +1975,88 @@
       renderHero();
       updateShelfPriority();
       updateDirtyState();
+    });
+
+    async function uploadImage(file) {
+      const token = getToken();
+      if (!token) throw new Error('Not logged in. Go back and log in first.');
+      const form = new FormData();
+      form.append('file', file, file.name || 'pasted-image.png');
+      const resp = await fetch(`${apiBase}/api/uploads`, {
+        method: 'POST',
+        headers: { 'Authorization': `Bearer ${token}` },
+        body: form,
+      });
+      const data = await resp.json().catch(() => ({}));
+      if (!resp.ok) throw new Error(data.detail || 'Image upload failed.');
+      return data.url;
+    }
+
+    let imageUploadCounter = 0;
+
+    function collectImageFiles(dataTransfer) {
+      const files = [];
+      const seen = new Set();
+      const push = f => {
+        if (!f) return;
+        const key = `${f.name}|${f.size}|${f.lastModified}`;
+        if (seen.has(key)) return;
+        seen.add(key);
+        if ((f.type && f.type.startsWith('image/')) || /\.(png|jpe?g|gif|webp|avif|heic|heif)$/i.test(f.name || '')) {
+          files.push(f);
+        }
+      };
+      for (const it of (dataTransfer?.items || [])) {
+        if (it.kind === 'file') push(it.getAsFile());
+      }
+      for (const f of (dataTransfer?.files || [])) push(f);
+      return files;
+    }
+
+    async function insertUploadedImage(ta, file) {
+      const placeholder = `![uploading-${++imageUploadCounter}…]()`;
+      const start = ta.selectionStart;
+      const end = ta.selectionEnd;
+      ta.value = ta.value.slice(0, start) + placeholder + ta.value.slice(end);
+      ta.selectionStart = ta.selectionEnd = start + placeholder.length;
+      ta.dispatchEvent(new Event('input', { bubbles: true }));
+      try {
+        const url = await uploadImage(file);
+        ta.value = ta.value.replace(placeholder, `<img src="${url}" width="400">`);
+      } catch (err) {
+        ta.value = ta.value.replace(placeholder, '');
+        setMessage(err.message, 'error');
+      }
+      ta.dispatchEvent(new Event('input', { bubbles: true }));
+    }
+
+    const reviewTextarea = document.getElementById('my_review');
+
+    reviewTextarea.addEventListener('paste', async e => {
+      const files = collectImageFiles(e.clipboardData);
+      if (!files.length) return;
+      e.preventDefault();
+      for (const file of files) await insertUploadedImage(reviewTextarea, file);
+    });
+
+    reviewTextarea.addEventListener('dragover', e => {
+      if (!Array.from(e.dataTransfer?.types || []).includes('Files')) return;
+      e.preventDefault();
+      e.dataTransfer.dropEffect = 'copy';
+      reviewTextarea.classList.add('drag-over');
+    });
+
+    reviewTextarea.addEventListener('dragleave', () => {
+      reviewTextarea.classList.remove('drag-over');
+    });
+
+    reviewTextarea.addEventListener('drop', async e => {
+      const files = collectImageFiles(e.dataTransfer);
+      reviewTextarea.classList.remove('drag-over');
+      if (!files.length) return;
+      e.preventDefault();
+      reviewTextarea.focus();
+      for (const file of files) await insertUploadedImage(reviewTextarea, file);
     });
 
     window.addEventListener('beforeunload', e => {

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -296,5 +296,98 @@ class SqliteApiTests(unittest.TestCase):
         self.assertEqual(invalid_response.status_code, 422)
 
 
+try:
+    from PIL import Image
+except ModuleNotFoundError:  # pragma: no cover - local env may not have project deps installed
+    Image = None
+
+
+@unittest.skipIf(TestClient is None, "fastapi is not installed")
+@unittest.skipIf(Image is None, "Pillow is not installed")
+class UploadApiTests(unittest.TestCase):
+    def setUp(self):
+        import io
+        import re
+
+        self.io = io
+        self.re = re
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.uploads_dir = Path(self.tempdir.name) / "uploads"
+        books_path = Path(self.tempdir.name) / "books.json"
+        llm_path = Path(self.tempdir.name) / "llm_cache.json"
+        books_path.write_text(
+            json.dumps({"generated_at": "2026-03-22T12:00:00Z", "books": {"read": [], "currently_reading": [], "to_read": []}, "stats": {}}),
+            encoding="utf-8",
+        )
+        llm_path.write_text("{}", encoding="utf-8")
+
+        self.original_env = os.environ.copy()
+        os.environ["DB_PATH"] = ""
+        os.environ["BOOKSHELF_AUTH_TOKEN"] = "test-token"
+        os.environ["BOOKS_DATA"] = str(books_path)
+        os.environ["LLM_CACHE_DATA"] = str(llm_path)
+        os.environ["UPLOADS_DIR"] = str(self.uploads_dir)
+
+        if "api.main" in sys.modules:
+            self.api_main = importlib.reload(sys.modules["api.main"])
+        else:
+            self.api_main = importlib.import_module("api.main")
+
+        self.client = TestClient(self.api_main.app)
+
+    def tearDown(self):
+        os.environ.clear()
+        os.environ.update(self.original_env)
+        self.tempdir.cleanup()
+
+    def _png_bytes(self, width, height):
+        buf = self.io.BytesIO()
+        Image.new("RGB", (width, height), (200, 120, 40)).save(buf, "PNG")
+        buf.seek(0)
+        return buf
+
+    def _post(self, content, headers=None, filename="test.png", content_type="image/png"):
+        return self.client.post(
+            "/api/uploads",
+            headers=headers if headers is not None else {"Authorization": "Bearer test-token"},
+            files={"file": (filename, content, content_type)},
+        )
+
+    def test_upload_requires_auth(self):
+        no_token = self._post(self._png_bytes(10, 10), headers={})
+        bad_token = self._post(self._png_bytes(10, 10), headers={"Authorization": "Bearer wrong"})
+        self.assertEqual(no_token.status_code, 401)
+        self.assertEqual(bad_token.status_code, 401)
+
+    def test_upload_resizes_and_converts_to_webp(self):
+        response = self._post(self._png_bytes(2400, 1200))
+        self.assertEqual(response.status_code, 201)
+        payload = response.json()
+        self.assertRegex(payload["url"], r"^/uploads/[0-9a-f]{32}\.webp$")
+
+        saved = self.uploads_dir / payload["filename"]
+        self.assertTrue(saved.exists())
+        with Image.open(saved) as img:
+            self.assertEqual(img.format, "WEBP")
+            self.assertLessEqual(img.width, 1600)
+
+    def test_upload_rejects_non_image(self):
+        response = self._post(self.io.BytesIO(b"not an image at all"))
+        self.assertEqual(response.status_code, 422)
+
+    def test_uploaded_file_is_served(self):
+        response = self._post(self._png_bytes(20, 20))
+        self.assertEqual(response.status_code, 201)
+        served = self.client.get(response.json()["url"])
+        self.assertEqual(served.status_code, 200)
+        self.assertEqual(served.headers["content-type"], "image/webp")
+
+    def test_small_image_not_upscaled(self):
+        response = self._post(self._png_bytes(300, 200))
+        self.assertEqual(response.status_code, 201)
+        with Image.open(self.uploads_dir / response.json()["filename"]) as img:
+            self.assertEqual(img.width, 300)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Closes #51.

## Summary

- Paste (Cmd+V) or drag-and-drop an image directly in the review editor. It uploads to `/api/uploads`, gets resized/re-encoded to WebP, and inserts `<img src="/uploads/…" width="400">` at the cursor so the number is easy to tweak.
- Server pipeline (`api/uploads.py`): Pillow validates real bytes (not just content-type header), fixes EXIF orientation and strips metadata (incl. GPS), resizes to ≤1600px wide, re-encodes to WebP quality 82. Filenames are `{uuid4}.webp`. Rejects >15 MB, empty, non-image, and unsupported formats (PNG/JPEG/WEBP allowed).
- Storage lives in `data/uploads/` — sibling to `bookshelf.db`, VPS-canonical, untouched by deploys (which only `--delete` under `site/`).
- Serving: nginx `location ^~ /uploads/` alias (the `^~` beats the existing static-extension regex); `StaticFiles` mount also registered so local `make dev` and TestClient work. Frontend rewrites `/uploads/` → `${apiBase}/uploads/` in local dev preview only.
- New `Editor tips` collapsible under the textarea documents the raw `<img>` sizing syntax (`width="300"`, `width="50%"`, `align="right"`, `<figure>`…).

## Ops changes

- `Makefile`: `deploy-sync` / `deploy-staging-sync` create + `chown www-data` `data/uploads`; new `pull-uploads`, `push-uploads`, `vps-install-deps` targets.
- `.gitignore`: `data/uploads/`.
- `api/requirements.txt`: `python-multipart==0.0.9`, `Pillow==10.3.0`.

## Deploy notes

After merge:
1. `make vps-install-deps` (or SSH and run `pip install -r api/requirements.txt` in the VPS venv).
2. `make deploy-staging`, verify on `dev.book.tanxy.net`.
3. Update nginx site config on VPS from `deploy/nginx.conf`, `nginx -t && systemctl reload nginx` (deploy-sync only ships the file into `$VPS_PATH/deploy/`).
4. `make deploy`.

## Test plan

- [x] `.venv/bin/python -m pytest tests/` — 178 passed, incl. 5 new upload tests (auth 401, 2400px PNG → ≤1600px WebP, non-image → 422, `GET /uploads/<file>` → 200, small image not upscaled).
- [x] Live `curl -X POST /api/uploads` with 2400×1200 PNG → 201, file served with `image/webp`, stored dimensions 1600×800.
- [x] CORS preflight from `http://localhost:8000` origin passes.
- [x] Local browser: paste + drag-and-drop insert `<img>`; preview and book page render the image.
- [ ] Staging deploy + nginx reload; `curl -I https://dev.book.tanxy.net/uploads/<file>` → 200 with 30d Cache-Control.
- [ ] Prod deploy; second deploy verifies existing uploads survive (`--delete` scoped to `site/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)